### PR TITLE
Server game engine - rooms and state machine

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hono/node-server": "^1.14.0",
@@ -17,6 +18,7 @@
   "devDependencies": {
     "tsx": "^4.19.0",
     "typescript": "^5.8.0",
-    "@types/node": "^22.0.0"
+    "@types/node": "^22.0.0",
+    "vitest": "^3.1.0"
   }
 }

--- a/apps/server/src/game/ActionResolver.ts
+++ b/apps/server/src/game/ActionResolver.ts
@@ -1,0 +1,116 @@
+import { ActionType } from "@majiang/shared";
+import type { GameAction } from "@majiang/shared";
+
+const ACTION_PRIORITY: Record<string, number> = {
+  [ActionType.Hu]: 4,
+  [ActionType.Peng]: 3,
+  [ActionType.MingGang]: 3,
+  [ActionType.Chi]: 2,
+  [ActionType.Pass]: 0,
+};
+
+function getActionPriority(action: GameAction): number {
+  return ACTION_PRIORITY[action.type] ?? 0;
+}
+
+export class ActionResolver {
+  private pendingResponses = new Map<number, GameAction | null>();
+  private expectedPlayers: number[];
+  private discarderIndex: number;
+  private resolvePromise: ((result: { playerIndex: number; action: GameAction } | null) => void) | null = null;
+  private timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(expectedPlayers: number[], discarderIndex: number) {
+    this.expectedPlayers = expectedPlayers;
+    this.discarderIndex = discarderIndex;
+    for (const p of expectedPlayers) {
+      this.pendingResponses.set(p, null);
+    }
+  }
+
+  submitAction(playerIndex: number, action: GameAction): void {
+    if (!this.expectedPlayers.includes(playerIndex)) return;
+    this.pendingResponses.set(playerIndex, action);
+    this.tryResolve();
+  }
+
+  waitForResponses(timeout: number): Promise<{ playerIndex: number; action: GameAction } | null> {
+    return new Promise((resolve) => {
+      this.resolvePromise = resolve;
+
+      this.timeoutHandle = setTimeout(() => {
+        // Auto-pass for anyone who hasn't responded
+        for (const p of this.expectedPlayers) {
+          if (this.pendingResponses.get(p) === null) {
+            this.pendingResponses.set(p, { type: ActionType.Pass, playerIndex: p });
+          }
+        }
+        this.tryResolve();
+      }, timeout);
+
+      // Check if already all resolved
+      this.tryResolve();
+    });
+  }
+
+  private tryResolve(): void {
+    if (!this.resolvePromise) return;
+
+    // Check if all players have responded
+    for (const p of this.expectedPlayers) {
+      if (this.pendingResponses.get(p) === null) return;
+    }
+
+    if (this.timeoutHandle) {
+      clearTimeout(this.timeoutHandle);
+      this.timeoutHandle = null;
+    }
+
+    // Find highest priority action
+    let bestAction: GameAction | null = null;
+    let bestPlayer = -1;
+    let bestPriority = -1;
+    let bestDistance = Infinity;
+
+    for (const p of this.expectedPlayers) {
+      const action = this.pendingResponses.get(p)!;
+      const priority = getActionPriority(action);
+
+      if (priority > bestPriority) {
+        bestPriority = priority;
+        bestAction = action;
+        bestPlayer = p;
+        bestDistance = this.distanceFromDiscarder(p);
+      } else if (priority === bestPriority && priority > 0) {
+        // Tie-break: closest to discarder (in turn order) wins
+        const dist = this.distanceFromDiscarder(p);
+        if (dist < bestDistance) {
+          bestAction = action;
+          bestPlayer = p;
+          bestDistance = dist;
+        }
+      }
+    }
+
+    const resolve = this.resolvePromise;
+    this.resolvePromise = null;
+
+    if (bestAction && bestPriority > 0) {
+      resolve({ playerIndex: bestPlayer, action: bestAction });
+    } else {
+      resolve(null); // All passed
+    }
+  }
+
+  private distanceFromDiscarder(playerIndex: number): number {
+    return (playerIndex - this.discarderIndex + 4) % 4;
+  }
+
+  dispose(): void {
+    if (this.timeoutHandle) {
+      clearTimeout(this.timeoutHandle);
+      this.timeoutHandle = null;
+    }
+    this.resolvePromise = null;
+  }
+}

--- a/apps/server/src/game/BotPlayer.ts
+++ b/apps/server/src/game/BotPlayer.ts
@@ -1,0 +1,73 @@
+import { ActionType } from "@majiang/shared";
+import type { GameAction, AvailableActions, TileInstance } from "@majiang/shared";
+
+export class BotPlayer {
+  static choosePostDrawAction(
+    actions: AvailableActions,
+    hand: TileInstance[],
+    playerIndex: number
+  ): GameAction {
+    // Priority: Hu > AnGang > Discard
+    if (actions.canHu) {
+      return { type: ActionType.Hu, playerIndex };
+    }
+
+    if (actions.anGangOptions.length > 0) {
+      return {
+        type: ActionType.AnGang,
+        playerIndex,
+        tile: actions.anGangOptions[0][0],
+      };
+    }
+
+    if (actions.buGangOptions.length > 0) {
+      return {
+        type: ActionType.BuGang,
+        playerIndex,
+        tile: actions.buGangOptions[0].tile,
+      };
+    }
+
+    // Discard a random tile
+    if (actions.canDiscard && hand.length > 0) {
+      const randomIndex = Math.floor(Math.random() * hand.length);
+      return {
+        type: ActionType.Discard,
+        playerIndex,
+        tile: hand[randomIndex],
+      };
+    }
+
+    // Fallback: discard first tile
+    return {
+      type: ActionType.Discard,
+      playerIndex,
+      tile: hand[0],
+    };
+  }
+
+  static chooseResponseAction(
+    actions: AvailableActions,
+    playerIndex: number
+  ): GameAction {
+    // Priority: Hu > Peng > Pass (no chi for basic bot)
+    if (actions.canHu) {
+      return { type: ActionType.Hu, playerIndex };
+    }
+
+    if (actions.canPeng) {
+      return { type: ActionType.Peng, playerIndex, targetTile: undefined as never };
+    }
+
+    if (actions.canMingGang) {
+      return { type: ActionType.MingGang, playerIndex, targetTile: undefined as never };
+    }
+
+    return { type: ActionType.Pass, playerIndex };
+  }
+
+  /** Delay to simulate thinking (returns ms) */
+  static getThinkDelay(): number {
+    return 500 + Math.floor(Math.random() * 500);
+  }
+}

--- a/apps/server/src/game/GameEngine.ts
+++ b/apps/server/src/game/GameEngine.ts
@@ -1,0 +1,670 @@
+import {
+  GamePhase,
+  MeldType,
+  ActionType,
+} from "@majiang/shared";
+import type {
+  RuleSet,
+  AvailableActions,
+  GameState,
+  PlayerState,
+  TileInstance,
+  Tile,
+  GameAction,
+  Meld,
+  ClientGameState,
+  ClientPlayerState,
+} from "@majiang/shared";
+import { ActionResolver } from "./ActionResolver.js";
+import { BotPlayer } from "./BotPlayer.js";
+
+const SEAT_WINDS = ["east", "south", "west", "north"] as const;
+const ACTION_TIMEOUT_MS = 15000;
+
+export interface GameEngineCallbacks {
+  onStateUpdate?: (playerIndex: number, state: ClientGameState) => void;
+  onActionRequired?: (playerIndex: number, actions: AvailableActions) => void;
+  onGameOver?: (result: { winnerId: number | null; winType: string; scores: number[] }) => void;
+  /** Set to 0 for tests to skip bot delays */
+  botDelayMs?: number;
+}
+
+export interface PlayerInfo {
+  name: string;
+  isBot: boolean;
+  socketId?: string;
+}
+
+export class GameEngine {
+  readonly gameState: GameState;
+  private ruleSet: RuleSet;
+  private players: PlayerInfo[];
+  private callbacks: GameEngineCallbacks;
+  private actionResolver: ActionResolver | null = null;
+  private lianZhuangCount = 0;
+  private scores: number[] = [0, 0, 0, 0];
+  private isProcessing = false;
+
+  constructor(ruleSet: RuleSet, players: PlayerInfo[], callbacks: GameEngineCallbacks = {}) {
+    this.ruleSet = ruleSet;
+    this.players = players;
+    this.callbacks = callbacks;
+
+    const dealerIndex = Math.floor(Math.random() * 4);
+    this.gameState = {
+      phase: GamePhase.Waiting,
+      players: players.map((p, i) => ({
+        name: p.name,
+        hand: [],
+        melds: [],
+        discards: [],
+        flowers: [],
+        isDealer: i === dealerIndex,
+        seatWind: SEAT_WINDS[(i - dealerIndex + 4) % 4],
+      })),
+      wall: [],
+      wallTail: [],
+      currentTurn: dealerIndex,
+      dealerIndex,
+      lastDiscard: null,
+      ruleSetId: ruleSet.id,
+    };
+  }
+
+  // --- Public API ---
+
+  async startGame(): Promise<void> {
+    this.deal();
+    await this.playLoop();
+  }
+
+  /** Submit an action from a player (called by socket handler or bot) */
+  submitAction(playerIndex: number, action: GameAction): void {
+    if (this.actionResolver) {
+      this.actionResolver.submitAction(playerIndex, action);
+    }
+  }
+
+  /** Generate client-safe state for a specific player */
+  toClientGameState(playerIndex: number): ClientGameState {
+    const gs = this.gameState;
+    return {
+      phase: gs.phase,
+      players: gs.players.map((p, i): ClientPlayerState => ({
+        name: p.name,
+        handCount: p.hand.length,
+        hand: i === playerIndex ? [...p.hand] : undefined,
+        melds: p.melds,
+        discards: [...p.discards],
+        flowers: [...p.flowers],
+        isDealer: p.isDealer,
+        seatWind: p.seatWind,
+      })),
+      currentTurn: gs.currentTurn,
+      dealerIndex: gs.dealerIndex,
+      wallRemaining: gs.wall.length,
+      wallTailRemaining: gs.wallTail.length,
+      lastDiscard: gs.lastDiscard,
+      ruleSetId: gs.ruleSetId,
+      myIndex: playerIndex,
+    };
+  }
+
+  getScores(): number[] {
+    return [...this.scores];
+  }
+
+  // --- Dealing Phase ---
+
+  private deal(): void {
+    this.gameState.phase = GamePhase.Dealing;
+
+    // Create and shuffle tiles
+    const tiles = this.ruleSet.createTilePool();
+    const tileInstances: TileInstance[] = tiles.map((tile, i) => ({ id: i, tile }));
+    this.shuffle(tileInstances);
+
+    // Split wall and wall tail (tail is last 14 tiles, used for flower replacement and gang draws)
+    const tailSize = Math.min(14, Math.floor(tileInstances.length / 4));
+    this.gameState.wallTail = tileInstances.splice(tileInstances.length - tailSize, tailSize);
+    this.gameState.wall = tileInstances;
+
+    // Deal initial hands
+    const handSize = this.ruleSet.initialHandSize;
+    for (let i = 0; i < 4; i++) {
+      this.gameState.players[i].hand = [];
+      this.gameState.players[i].melds = [];
+      this.gameState.players[i].discards = [];
+      this.gameState.players[i].flowers = [];
+    }
+
+    for (let round = 0; round < handSize; round++) {
+      for (let i = 0; i < 4; i++) {
+        const tile = this.drawFromWall();
+        if (tile) {
+          this.gameState.players[i].hand.push(tile);
+        }
+      }
+    }
+
+    // Replace bonus tiles if applicable
+    if (this.ruleSet.hasBonusTiles) {
+      for (let i = 0; i < 4; i++) {
+        this.replaceBonusTiles(i);
+      }
+    }
+
+    this.gameState.phase = GamePhase.Playing;
+    this.broadcastState();
+  }
+
+  // --- Playing Phase ---
+
+  private async playLoop(): Promise<void> {
+    while (this.gameState.phase === GamePhase.Playing) {
+      const turn = this.gameState.currentTurn;
+
+      // Draw a tile
+      const drawn = this.drawTileForPlayer(turn);
+      if (!drawn) {
+        this.endGameDraw();
+        return;
+      }
+
+      this.broadcastState();
+
+      // Get post-draw actions from ruleset
+      const postDrawActions = this.ruleSet.getPostDrawActions(
+        this.gameState.players[turn],
+        drawn,
+        { gameState: this.gameState, playerIndex: turn }
+      );
+
+      // Wait for player action
+      const postDrawAction = await this.waitForPlayerAction(turn, postDrawActions, drawn);
+
+      if (postDrawAction.type === ActionType.Hu) {
+        const won = this.handleHu(turn, drawn, true);
+        if (won) return;
+        // If hu check failed, force a discard
+        continue;
+      }
+
+      if (postDrawAction.type === ActionType.AnGang) {
+        this.executeAnGang(turn, postDrawAction.tile);
+        // After gang, player draws again from wall tail
+        continue;
+      }
+
+      if (postDrawAction.type === ActionType.BuGang) {
+        this.executeBuGang(turn, postDrawAction.tile);
+        // After gang, player draws again from wall tail
+        continue;
+      }
+
+      if (postDrawAction.type === ActionType.Discard) {
+        this.executeDiscard(turn, postDrawAction.tile);
+        this.broadcastState();
+
+        // Get responses from other players
+        const claimResult = await this.handleDiscardResponses(turn, postDrawAction.tile);
+
+        if (claimResult) {
+          if (claimResult.action.type === ActionType.Hu) {
+            const won = this.handleHu(claimResult.playerIndex, postDrawAction.tile, false);
+            if (won) return;
+          } else if (claimResult.action.type === ActionType.Peng) {
+            this.executePeng(claimResult.playerIndex, turn, postDrawAction.tile);
+            // After peng, claiming player must discard
+            const pengDiscardAction = await this.waitForPengDiscard(claimResult.playerIndex);
+            this.executeDiscard(claimResult.playerIndex, (pengDiscardAction as { tile: TileInstance }).tile);
+            this.broadcastState();
+
+            const pengClaimResult = await this.handleDiscardResponses(
+              claimResult.playerIndex,
+              (pengDiscardAction as { tile: TileInstance }).tile
+            );
+            if (pengClaimResult) {
+              this.handleClaim(pengClaimResult, claimResult.playerIndex);
+              if (this.gameState.phase !== GamePhase.Playing) return;
+            } else {
+              this.advanceTurn(claimResult.playerIndex);
+            }
+            continue;
+          } else if (claimResult.action.type === ActionType.MingGang) {
+            this.executeMingGang(claimResult.playerIndex, turn, postDrawAction.tile);
+            this.gameState.currentTurn = claimResult.playerIndex;
+            // Gang player draws from tail next turn
+            continue;
+          } else if (claimResult.action.type === ActionType.Chi) {
+            this.executeChi(
+              claimResult.playerIndex,
+              turn,
+              postDrawAction.tile,
+              (claimResult.action as { tiles: [TileInstance, TileInstance] }).tiles
+            );
+            // After chi, claiming player must discard
+            const chiDiscardAction = await this.waitForPengDiscard(claimResult.playerIndex);
+            this.executeDiscard(claimResult.playerIndex, (chiDiscardAction as { tile: TileInstance }).tile);
+            this.broadcastState();
+
+            const chiClaimResult = await this.handleDiscardResponses(
+              claimResult.playerIndex,
+              (chiDiscardAction as { tile: TileInstance }).tile
+            );
+            if (chiClaimResult) {
+              this.handleClaim(chiClaimResult, claimResult.playerIndex);
+              if (this.gameState.phase !== GamePhase.Playing) return;
+            } else {
+              this.advanceTurn(claimResult.playerIndex);
+            }
+            continue;
+          }
+        }
+
+        // No one claimed, advance to next player
+        this.advanceTurn(turn);
+      }
+    }
+  }
+
+  private handleClaim(
+    claimResult: { playerIndex: number; action: GameAction },
+    discarderIndex: number
+  ): void {
+    const discardTile = this.gameState.lastDiscard?.tile;
+    if (!discardTile) return;
+
+    if (claimResult.action.type === ActionType.Hu) {
+      this.handleHu(claimResult.playerIndex, discardTile, false);
+    } else if (claimResult.action.type === ActionType.Peng) {
+      this.executePeng(claimResult.playerIndex, discarderIndex, discardTile);
+      this.gameState.currentTurn = claimResult.playerIndex;
+    } else if (claimResult.action.type === ActionType.MingGang) {
+      this.executeMingGang(claimResult.playerIndex, discarderIndex, discardTile);
+      this.gameState.currentTurn = claimResult.playerIndex;
+    }
+  }
+
+  // --- Action Handlers ---
+
+  private async waitForPlayerAction(
+    playerIndex: number,
+    actions: AvailableActions,
+    drawnTile: TileInstance
+  ): Promise<GameAction> {
+    this.callbacks.onActionRequired?.(playerIndex, actions);
+
+    if (this.players[playerIndex].isBot) {
+      const delayMs = this.callbacks.botDelayMs ?? BotPlayer.getThinkDelay();
+      if (delayMs > 0) await this.delay(delayMs);
+      return BotPlayer.choosePostDrawAction(
+        actions,
+        this.gameState.players[playerIndex].hand,
+        playerIndex
+      );
+    }
+
+    // Wait for human player via ActionResolver
+    const resolver = new ActionResolver([playerIndex], playerIndex);
+    this.actionResolver = resolver;
+
+    const result = await resolver.waitForResponses(ACTION_TIMEOUT_MS);
+    this.actionResolver = null;
+
+    if (result) {
+      return result.action;
+    }
+
+    // Timeout: auto-discard the drawn tile
+    return { type: ActionType.Discard, playerIndex, tile: drawnTile };
+  }
+
+  private async waitForPengDiscard(playerIndex: number): Promise<GameAction> {
+    const player = this.gameState.players[playerIndex];
+    const actions: AvailableActions = {
+      canDraw: false,
+      canDiscard: true,
+      canHu: false,
+      canPeng: false,
+      canMingGang: false,
+      canPass: false,
+      chiOptions: [],
+      anGangOptions: [],
+      buGangOptions: [],
+    };
+
+    this.callbacks.onActionRequired?.(playerIndex, actions);
+
+    if (this.players[playerIndex].isBot) {
+      const delayMs = this.callbacks.botDelayMs ?? BotPlayer.getThinkDelay();
+      if (delayMs > 0) await this.delay(delayMs);
+      const randomIndex = Math.floor(Math.random() * player.hand.length);
+      return { type: ActionType.Discard, playerIndex, tile: player.hand[randomIndex] };
+    }
+
+    const resolver = new ActionResolver([playerIndex], playerIndex);
+    this.actionResolver = resolver;
+
+    const result = await resolver.waitForResponses(ACTION_TIMEOUT_MS);
+    this.actionResolver = null;
+
+    if (result) {
+      return result.action;
+    }
+
+    // Timeout: discard first tile
+    return { type: ActionType.Discard, playerIndex, tile: player.hand[0] };
+  }
+
+  private async handleDiscardResponses(
+    discarderIndex: number,
+    discardedTile: TileInstance
+  ): Promise<{ playerIndex: number; action: GameAction } | null> {
+    const respondingPlayers: number[] = [];
+
+    for (let i = 0; i < 4; i++) {
+      if (i === discarderIndex) continue;
+      const responseActions = this.ruleSet.getResponseActions(
+        this.gameState.players[i],
+        discardedTile,
+        { gameState: this.gameState, playerIndex: i, discarderIndex }
+      );
+
+      // Only include players that have options beyond just pass
+      if (
+        responseActions.canHu ||
+        responseActions.canPeng ||
+        responseActions.canMingGang ||
+        responseActions.chiOptions.length > 0
+      ) {
+        respondingPlayers.push(i);
+        this.callbacks.onActionRequired?.(i, responseActions);
+      }
+    }
+
+    if (respondingPlayers.length === 0) return null;
+
+    const resolver = new ActionResolver(respondingPlayers, discarderIndex);
+    this.actionResolver = resolver;
+
+    // Bots respond automatically
+    for (const p of respondingPlayers) {
+      if (this.players[p].isBot) {
+        const responseActions = this.ruleSet.getResponseActions(
+          this.gameState.players[p],
+          discardedTile,
+          { gameState: this.gameState, playerIndex: p, discarderIndex }
+        );
+        const botDelay = this.callbacks.botDelayMs ?? BotPlayer.getThinkDelay();
+        setTimeout(() => {
+          const botAction = BotPlayer.chooseResponseAction(responseActions, p);
+          // Fill in targetTile for peng/gang
+          if (botAction.type === ActionType.Peng || botAction.type === ActionType.MingGang) {
+            (botAction as { targetTile: TileInstance }).targetTile = discardedTile;
+          }
+          resolver.submitAction(p, botAction);
+        }, botDelay);
+      }
+    }
+
+    const result = await resolver.waitForResponses(ACTION_TIMEOUT_MS);
+    this.actionResolver = null;
+
+    return result;
+  }
+
+  // --- Execute Actions ---
+
+  private executeDiscard(playerIndex: number, tile: TileInstance): void {
+    const player = this.gameState.players[playerIndex];
+    const idx = player.hand.findIndex((t) => t.id === tile.id);
+    if (idx === -1) return;
+    player.hand.splice(idx, 1);
+    player.discards.push(tile);
+    this.gameState.lastDiscard = { tile, playerIndex };
+  }
+
+  private executePeng(claimingPlayer: number, sourcePlayer: number, tile: TileInstance): void {
+    const player = this.gameState.players[claimingPlayer];
+    const matching = player.hand.filter((t) => tilesMatch(t.tile, tile.tile));
+    const meldTiles = matching.slice(0, 2);
+
+    // Remove from hand
+    for (const mt of meldTiles) {
+      const idx = player.hand.findIndex((t) => t.id === mt.id);
+      if (idx !== -1) player.hand.splice(idx, 1);
+    }
+
+    // Remove from discarder's discards
+    const discarder = this.gameState.players[sourcePlayer];
+    const discardIdx = discarder.discards.findIndex((t) => t.id === tile.id);
+    if (discardIdx !== -1) discarder.discards.splice(discardIdx, 1);
+
+    const meld: Meld = {
+      type: MeldType.Peng,
+      tiles: [...meldTiles, tile],
+      sourceTile: tile,
+      sourcePlayer,
+    };
+    player.melds.push(meld);
+    this.gameState.currentTurn = claimingPlayer;
+    this.gameState.lastDiscard = null;
+  }
+
+  private executeMingGang(claimingPlayer: number, sourcePlayer: number, tile: TileInstance): void {
+    const player = this.gameState.players[claimingPlayer];
+    const matching = player.hand.filter((t) => tilesMatch(t.tile, tile.tile));
+    const meldTiles = matching.slice(0, 3);
+
+    for (const mt of meldTiles) {
+      const idx = player.hand.findIndex((t) => t.id === mt.id);
+      if (idx !== -1) player.hand.splice(idx, 1);
+    }
+
+    const discarder = this.gameState.players[sourcePlayer];
+    const discardIdx = discarder.discards.findIndex((t) => t.id === tile.id);
+    if (discardIdx !== -1) discarder.discards.splice(discardIdx, 1);
+
+    const meld: Meld = {
+      type: MeldType.MingGang,
+      tiles: [...meldTiles, tile],
+      sourceTile: tile,
+      sourcePlayer,
+    };
+    player.melds.push(meld);
+    this.gameState.lastDiscard = null;
+  }
+
+  private executeAnGang(playerIndex: number, tile: TileInstance): void {
+    const player = this.gameState.players[playerIndex];
+    const matching = player.hand.filter((t) => tilesMatch(t.tile, tile.tile));
+    const meldTiles = matching.slice(0, 4);
+
+    for (const mt of meldTiles) {
+      const idx = player.hand.findIndex((t) => t.id === mt.id);
+      if (idx !== -1) player.hand.splice(idx, 1);
+    }
+
+    const meld: Meld = {
+      type: MeldType.AnGang,
+      tiles: meldTiles,
+    };
+    player.melds.push(meld);
+  }
+
+  private executeBuGang(playerIndex: number, tile: TileInstance): void {
+    const player = this.gameState.players[playerIndex];
+    // Find the peng meld to upgrade
+    const meldIndex = player.melds.findIndex(
+      (m) => m.type === MeldType.Peng && tilesMatch(m.tiles[0].tile, tile.tile)
+    );
+    if (meldIndex === -1) return;
+
+    const idx = player.hand.findIndex((t) => t.id === tile.id);
+    if (idx !== -1) player.hand.splice(idx, 1);
+
+    player.melds[meldIndex].type = MeldType.BuGang;
+    player.melds[meldIndex].tiles.push(tile);
+  }
+
+  private executeChi(
+    claimingPlayer: number,
+    sourcePlayer: number,
+    targetTile: TileInstance,
+    chiTiles: [TileInstance, TileInstance]
+  ): void {
+    const player = this.gameState.players[claimingPlayer];
+
+    for (const ct of chiTiles) {
+      const idx = player.hand.findIndex((t) => t.id === ct.id);
+      if (idx !== -1) player.hand.splice(idx, 1);
+    }
+
+    const discarder = this.gameState.players[sourcePlayer];
+    const discardIdx = discarder.discards.findIndex((t) => t.id === targetTile.id);
+    if (discardIdx !== -1) discarder.discards.splice(discardIdx, 1);
+
+    const meld: Meld = {
+      type: MeldType.Chi,
+      tiles: [...chiTiles, targetTile],
+      sourceTile: targetTile,
+      sourcePlayer,
+    };
+    player.melds.push(meld);
+    this.gameState.currentTurn = claimingPlayer;
+    this.gameState.lastDiscard = null;
+  }
+
+  private handleHu(playerIndex: number, winningTile: TileInstance, isSelfDraw: boolean): boolean {
+    const player = this.gameState.players[playerIndex];
+    const winResult = this.ruleSet.checkWin(player, winningTile, {
+      isSelfDraw,
+      isFirstAction: player.discards.length === 0 && player.melds.length === 0,
+      isDealer: player.isDealer,
+      isRobbingKong: false,
+    });
+
+    if (!winResult.isWin) return false;
+
+    const scoreResult = this.ruleSet.calculateScore(
+      player,
+      playerIndex,
+      winResult,
+      {
+        isSelfDraw,
+        discarderIndex: isSelfDraw ? null : this.gameState.lastDiscard?.playerIndex ?? null,
+      }
+    );
+
+    for (let i = 0; i < 4; i++) {
+      this.scores[i] += scoreResult.payments[i];
+    }
+
+    this.gameState.phase = GamePhase.Finished;
+    this.broadcastState();
+
+    this.callbacks.onGameOver?.({
+      winnerId: playerIndex,
+      winType: winResult.winType ?? "hu",
+      scores: [...this.scores],
+    });
+
+    return true;
+  }
+
+  // --- Tile Management ---
+
+  private drawFromWall(): TileInstance | null {
+    return this.gameState.wall.shift() ?? null;
+  }
+
+  private drawFromWallTail(): TileInstance | null {
+    return this.gameState.wallTail.shift() ?? null;
+  }
+
+  private drawTileForPlayer(playerIndex: number): TileInstance | null {
+    let tile = this.drawFromWall();
+    if (!tile) return null;
+
+    // Handle bonus tiles
+    if (this.ruleSet.hasBonusTiles) {
+      while (tile && this.ruleSet.isBonusTile(tile.tile)) {
+        this.gameState.players[playerIndex].flowers.push(tile);
+        this.broadcastState();
+        tile = this.drawFromWallTail();
+      }
+    }
+
+    if (tile) {
+      this.gameState.players[playerIndex].hand.push(tile);
+    }
+    return tile;
+  }
+
+  private replaceBonusTiles(playerIndex: number): void {
+    const player = this.gameState.players[playerIndex];
+    let replaced = true;
+    while (replaced) {
+      replaced = false;
+      for (let i = player.hand.length - 1; i >= 0; i--) {
+        if (this.ruleSet.isBonusTile(player.hand[i].tile)) {
+          const bonusTile = player.hand.splice(i, 1)[0];
+          player.flowers.push(bonusTile);
+          const replacement = this.drawFromWallTail();
+          if (replacement) {
+            player.hand.push(replacement);
+            replaced = true;
+          }
+        }
+      }
+    }
+  }
+
+  // --- Turn Management ---
+
+  private advanceTurn(currentPlayer: number): void {
+    this.gameState.currentTurn = (currentPlayer + 1) % 4;
+  }
+
+  private endGameDraw(): void {
+    this.gameState.phase = GamePhase.Draw;
+    this.broadcastState();
+    this.callbacks.onGameOver?.({
+      winnerId: null,
+      winType: "draw",
+      scores: [...this.scores],
+    });
+  }
+
+  // --- Helpers ---
+
+  private broadcastState(): void {
+    for (let i = 0; i < 4; i++) {
+      this.callbacks.onStateUpdate?.(i, this.toClientGameState(i));
+    }
+  }
+
+  private shuffle(arr: TileInstance[]): void {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+function tilesMatch(a: Tile, b: Tile): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "suited" && b.kind === "suited") {
+    return a.suit === b.suit && a.value === b.value;
+  }
+  if (a.kind === "wind" && b.kind === "wind") return a.windType === b.windType;
+  if (a.kind === "dragon" && b.kind === "dragon") return a.dragonType === b.dragonType;
+  if (a.kind === "season" && b.kind === "season") return a.seasonType === b.seasonType;
+  if (a.kind === "plant" && b.kind === "plant") return a.plantType === b.plantType;
+  return false;
+}

--- a/apps/server/src/game/Room.ts
+++ b/apps/server/src/game/Room.ts
@@ -1,0 +1,117 @@
+import type { RuleSet, RoomInfo } from "@majiang/shared";
+import { getRuleSet } from "@majiang/shared";
+import { GameEngine } from "./GameEngine.js";
+import type { GameEngineCallbacks, PlayerInfo } from "./GameEngine.js";
+
+const MAX_PLAYERS = 4;
+
+let roomCounter = 0;
+function generateRoomId(): string {
+  roomCounter++;
+  return `room-${Date.now().toString(36)}-${roomCounter}`;
+}
+
+export interface RoomPlayer {
+  name: string;
+  isBot: boolean;
+  socketId?: string;
+  ready: boolean;
+}
+
+export class Room {
+  readonly id: string;
+  readonly ruleSetId: string;
+  players: RoomPlayer[] = [];
+  state: "waiting" | "playing" | "finished" = "waiting";
+  engine: GameEngine | null = null;
+
+  constructor(ruleSetId: string) {
+    this.id = generateRoomId();
+    this.ruleSetId = ruleSetId;
+  }
+
+  addPlayer(name: string, socketId?: string, isBot = false): boolean {
+    if (this.players.length >= MAX_PLAYERS) return false;
+    if (this.state !== "waiting") return false;
+
+    this.players.push({ name, isBot, socketId, ready: true });
+    return true;
+  }
+
+  removePlayer(socketId: string): boolean {
+    if (this.state !== "waiting") return false;
+
+    const idx = this.players.findIndex((p) => p.socketId === socketId);
+    if (idx === -1) return false;
+
+    this.players.splice(idx, 1);
+    return true;
+  }
+
+  addBot(name: string): boolean {
+    return this.addPlayer(name, undefined, true);
+  }
+
+  canStart(): boolean {
+    return this.players.length === MAX_PLAYERS && this.state === "waiting";
+  }
+
+  start(callbacks: GameEngineCallbacks = {}): GameEngine {
+    if (!this.canStart()) {
+      throw new Error("Cannot start game: need exactly 4 players in waiting state");
+    }
+
+    const ruleSet = getRuleSet(this.ruleSetId);
+    if (!ruleSet) {
+      throw new Error(`RuleSet "${this.ruleSetId}" not found in registry`);
+    }
+
+    const playerInfos: PlayerInfo[] = this.players.map((p) => ({
+      name: p.name,
+      isBot: p.isBot,
+      socketId: p.socketId,
+    }));
+
+    this.engine = new GameEngine(ruleSet, playerInfos, callbacks);
+    this.state = "playing";
+    return this.engine;
+  }
+
+  toRoomInfo(): RoomInfo {
+    return {
+      id: this.id,
+      players: this.players.map((p) => ({
+        name: p.name,
+        isBot: p.isBot,
+        ready: p.ready,
+      })),
+      ruleSetId: this.ruleSetId,
+      started: this.state !== "waiting",
+    };
+  }
+}
+
+export class RoomManager {
+  private rooms = new Map<string, Room>();
+
+  createRoom(ruleSetId: string): Room {
+    const room = new Room(ruleSetId);
+    this.rooms.set(room.id, room);
+    return room;
+  }
+
+  getRoom(id: string): Room | undefined {
+    return this.rooms.get(id);
+  }
+
+  listRooms(): Room[] {
+    return Array.from(this.rooms.values());
+  }
+
+  removeRoom(id: string): boolean {
+    return this.rooms.delete(id);
+  }
+}
+
+// Singleton instance
+export const roomManager = new RoomManager();

--- a/apps/server/src/game/__tests__/ActionResolver.test.ts
+++ b/apps/server/src/game/__tests__/ActionResolver.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { ActionType } from "@majiang/shared";
+import { ActionResolver } from "../ActionResolver.js";
+
+describe("ActionResolver", () => {
+  it("should resolve with null when all players pass", async () => {
+    const resolver = new ActionResolver([1, 2, 3], 0);
+
+    resolver.submitAction(1, { type: ActionType.Pass, playerIndex: 1 });
+    resolver.submitAction(2, { type: ActionType.Pass, playerIndex: 2 });
+    resolver.submitAction(3, { type: ActionType.Pass, playerIndex: 3 });
+
+    const result = await resolver.waitForResponses(5000);
+    expect(result).toBeNull();
+  });
+
+  it("should resolve with highest priority action (hu > peng)", async () => {
+    const resolver = new ActionResolver([1, 2, 3], 0);
+
+    resolver.submitAction(1, { type: ActionType.Peng, playerIndex: 1, targetTile: { id: 0, tile: { kind: "suited", suit: "wan" as any, value: 1 as any } } });
+    resolver.submitAction(2, { type: ActionType.Hu, playerIndex: 2 });
+    resolver.submitAction(3, { type: ActionType.Pass, playerIndex: 3 });
+
+    const result = await resolver.waitForResponses(5000);
+    expect(result).not.toBeNull();
+    expect(result!.action.type).toBe(ActionType.Hu);
+    expect(result!.playerIndex).toBe(2);
+  });
+
+  it("should resolve peng over chi", async () => {
+    const resolver = new ActionResolver([1, 2, 3], 0);
+
+    resolver.submitAction(1, { type: ActionType.Chi, playerIndex: 1, tiles: [] as any, targetTile: { id: 0, tile: { kind: "suited", suit: "wan" as any, value: 1 as any } } });
+    resolver.submitAction(2, { type: ActionType.Peng, playerIndex: 2, targetTile: { id: 0, tile: { kind: "suited", suit: "wan" as any, value: 1 as any } } });
+    resolver.submitAction(3, { type: ActionType.Pass, playerIndex: 3 });
+
+    const result = await resolver.waitForResponses(5000);
+    expect(result).not.toBeNull();
+    expect(result!.action.type).toBe(ActionType.Peng);
+    expect(result!.playerIndex).toBe(2);
+  });
+
+  it("should break ties by distance from discarder", async () => {
+    // Discarder is player 0. Players 1 and 3 both peng.
+    // Player 1 is closer (distance 1 vs distance 3)
+    const resolver = new ActionResolver([1, 2, 3], 0);
+
+    resolver.submitAction(1, { type: ActionType.Peng, playerIndex: 1, targetTile: { id: 0, tile: { kind: "suited", suit: "wan" as any, value: 1 as any } } });
+    resolver.submitAction(2, { type: ActionType.Pass, playerIndex: 2 });
+    resolver.submitAction(3, { type: ActionType.Peng, playerIndex: 3, targetTile: { id: 0, tile: { kind: "suited", suit: "wan" as any, value: 1 as any } } });
+
+    const result = await resolver.waitForResponses(5000);
+    expect(result).not.toBeNull();
+    expect(result!.playerIndex).toBe(1);
+  });
+
+  it("should auto-pass on timeout", async () => {
+    const resolver = new ActionResolver([1, 2, 3], 0);
+
+    // Only player 1 responds
+    resolver.submitAction(1, { type: ActionType.Pass, playerIndex: 1 });
+
+    // Short timeout
+    const result = await resolver.waitForResponses(50);
+    // All others auto-pass
+    expect(result).toBeNull();
+  });
+
+  it("should handle single player response", async () => {
+    const resolver = new ActionResolver([2], 0);
+
+    resolver.submitAction(2, { type: ActionType.Peng, playerIndex: 2, targetTile: { id: 0, tile: { kind: "suited", suit: "wan" as any, value: 1 as any } } });
+
+    const result = await resolver.waitForResponses(5000);
+    expect(result).not.toBeNull();
+    expect(result!.action.type).toBe(ActionType.Peng);
+  });
+
+  it("should ignore actions from unexpected players", async () => {
+    const resolver = new ActionResolver([1, 2], 0);
+
+    resolver.submitAction(1, { type: ActionType.Pass, playerIndex: 1 });
+    resolver.submitAction(2, { type: ActionType.Pass, playerIndex: 2 });
+    resolver.submitAction(3, { type: ActionType.Hu, playerIndex: 3 }); // Not expected
+
+    const result = await resolver.waitForResponses(5000);
+    expect(result).toBeNull(); // Only passes from expected players
+  });
+});

--- a/apps/server/src/game/__tests__/BotPlayer.test.ts
+++ b/apps/server/src/game/__tests__/BotPlayer.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { ActionType, Suit } from "@majiang/shared";
+import type { AvailableActions, TileInstance } from "@majiang/shared";
+import { BotPlayer } from "../BotPlayer.js";
+
+function makeTile(id: number, value: number): TileInstance {
+  return { id, tile: { kind: "suited", suit: Suit.Wan, value: value as 1 } };
+}
+
+const noActions: AvailableActions = {
+  canDraw: false,
+  canDiscard: true,
+  canHu: false,
+  canPeng: false,
+  canMingGang: false,
+  canPass: false,
+  chiOptions: [],
+  anGangOptions: [],
+  buGangOptions: [],
+};
+
+describe("BotPlayer", () => {
+  describe("choosePostDrawAction", () => {
+    it("should hu when possible", () => {
+      const actions: AvailableActions = { ...noActions, canHu: true };
+      const hand = [makeTile(0, 1), makeTile(1, 2)];
+      const result = BotPlayer.choosePostDrawAction(actions, hand, 0);
+      expect(result.type).toBe(ActionType.Hu);
+    });
+
+    it("should anGang when possible and not hu", () => {
+      const gangTiles = [makeTile(0, 1), makeTile(1, 1), makeTile(2, 1), makeTile(3, 1)];
+      const actions: AvailableActions = {
+        ...noActions,
+        anGangOptions: [gangTiles],
+      };
+      const hand = [...gangTiles, makeTile(4, 2)];
+      const result = BotPlayer.choosePostDrawAction(actions, hand, 0);
+      expect(result.type).toBe(ActionType.AnGang);
+    });
+
+    it("should discard when no special actions available", () => {
+      const hand = [makeTile(0, 1), makeTile(1, 2), makeTile(2, 3)];
+      const result = BotPlayer.choosePostDrawAction(noActions, hand, 0);
+      expect(result.type).toBe(ActionType.Discard);
+      expect(hand.map((t) => t.id)).toContain((result as { tile: TileInstance }).tile.id);
+    });
+  });
+
+  describe("chooseResponseAction", () => {
+    it("should hu when possible", () => {
+      const actions: AvailableActions = { ...noActions, canHu: true, canPass: true };
+      const result = BotPlayer.chooseResponseAction(actions, 1);
+      expect(result.type).toBe(ActionType.Hu);
+    });
+
+    it("should peng when possible and not hu", () => {
+      const actions: AvailableActions = { ...noActions, canPeng: true, canPass: true };
+      const result = BotPlayer.chooseResponseAction(actions, 1);
+      expect(result.type).toBe(ActionType.Peng);
+    });
+
+    it("should pass when nothing special available", () => {
+      const actions: AvailableActions = { ...noActions, canPass: true, canDiscard: false };
+      const result = BotPlayer.chooseResponseAction(actions, 1);
+      expect(result.type).toBe(ActionType.Pass);
+    });
+  });
+
+  describe("getThinkDelay", () => {
+    it("should return a delay between 500 and 1000ms", () => {
+      for (let i = 0; i < 20; i++) {
+        const delay = BotPlayer.getThinkDelay();
+        expect(delay).toBeGreaterThanOrEqual(500);
+        expect(delay).toBeLessThan(1000);
+      }
+    });
+  });
+});

--- a/apps/server/src/game/__tests__/GameEngine.test.ts
+++ b/apps/server/src/game/__tests__/GameEngine.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GamePhase, registerRuleSet } from "@majiang/shared";
+import type { ClientGameState, AvailableActions } from "@majiang/shared";
+import { GameEngine } from "../GameEngine.js";
+import type { PlayerInfo, GameEngineCallbacks } from "../GameEngine.js";
+import { StubRuleSet } from "./StubRuleSet.js";
+
+registerRuleSet(StubRuleSet);
+
+const testPlayers: PlayerInfo[] = [
+  { name: "Alice", isBot: true },
+  { name: "Bob", isBot: true },
+  { name: "Charlie", isBot: true },
+  { name: "Diana", isBot: true },
+];
+
+describe("GameEngine", () => {
+  it("should create with correct initial state", () => {
+    const engine = new GameEngine(StubRuleSet, testPlayers);
+    const gs = engine.gameState;
+
+    expect(gs.phase).toBe(GamePhase.Waiting);
+    expect(gs.players).toHaveLength(4);
+    expect(gs.ruleSetId).toBe("stub");
+
+    // Exactly one dealer
+    const dealers = gs.players.filter((p) => p.isDealer);
+    expect(dealers).toHaveLength(1);
+
+    // All seat winds assigned
+    const winds = gs.players.map((p) => p.seatWind);
+    expect(winds).toContain("east");
+    expect(winds).toContain("south");
+    expect(winds).toContain("west");
+    expect(winds).toContain("north");
+  });
+
+  it("should deal tiles and transition to playing", async () => {
+    const stateUpdates: ClientGameState[] = [];
+    const callbacks: GameEngineCallbacks = {
+      onStateUpdate: (_idx, state) => stateUpdates.push(state),
+      onGameOver: () => {},
+      botDelayMs: 0,
+    };
+
+    const engine = new GameEngine(StubRuleSet, testPlayers, callbacks);
+
+    // Start game (bots play automatically, game will finish)
+    await engine.startGame();
+
+    // Game should have ended (either finished or draw)
+    expect([GamePhase.Finished, GamePhase.Draw]).toContain(engine.gameState.phase);
+
+    // Should have received state updates
+    expect(stateUpdates.length).toBeGreaterThan(0);
+  });
+
+  it("should deal correct number of tiles to each player", () => {
+    const engine = new GameEngine(StubRuleSet, testPlayers);
+
+    // Access deal via startGame — but we need to check state after dealing
+    // We'll manually check by looking at the first state update
+    const states: ClientGameState[] = [];
+    const engineWithCallbacks = new GameEngine(StubRuleSet, testPlayers, {
+      onStateUpdate: (idx, state) => {
+        if (idx === 0) states.push(state);
+      },
+    });
+
+    // The first state update after deal should have 13 tiles per player
+    const firstUpdatePromise = new Promise<ClientGameState>((resolve) => {
+      new GameEngine(StubRuleSet, testPlayers, {
+        onStateUpdate: (idx, state) => {
+          if (idx === 0 && state.phase === GamePhase.Playing) {
+            resolve(state);
+          }
+        },
+        botDelayMs: 0,
+      }).startGame();
+    });
+
+    return firstUpdatePromise.then((state) => {
+      // Player 0 should see their own hand
+      expect(state.players[0].hand).toBeDefined();
+      expect(state.players[0].hand!.length).toBe(StubRuleSet.initialHandSize);
+
+      // Other players' hands should be hidden
+      expect(state.players[1].hand).toBeUndefined();
+      expect(state.players[2].hand).toBeUndefined();
+      expect(state.players[3].hand).toBeUndefined();
+
+      // But handCount should be set
+      expect(state.players[1].handCount).toBe(StubRuleSet.initialHandSize);
+    });
+  });
+
+  it("should produce valid ClientGameState that hides other hands", () => {
+    const engine = new GameEngine(StubRuleSet, testPlayers);
+
+    // Manually check toClientGameState
+    const clientState = engine.toClientGameState(2);
+    expect(clientState.myIndex).toBe(2);
+    expect(clientState.ruleSetId).toBe("stub");
+
+    // Player 2 should see their own hand (empty before deal)
+    expect(clientState.players[2].hand).toBeDefined();
+    // Other players should not
+    expect(clientState.players[0].hand).toBeUndefined();
+    expect(clientState.players[1].hand).toBeUndefined();
+    expect(clientState.players[3].hand).toBeUndefined();
+  });
+
+  it("should complete a full game with all bots", async () => {
+    let gameOverResult: { winnerId: number | null; winType: string; scores: number[] } | null = null;
+
+    const engine = new GameEngine(StubRuleSet, testPlayers, {
+      onGameOver: (result) => {
+        gameOverResult = result;
+      },
+      botDelayMs: 0,
+    });
+
+    await engine.startGame();
+
+    expect(gameOverResult).not.toBeNull();
+    expect(gameOverResult!.scores).toHaveLength(4);
+
+    if (gameOverResult!.winnerId !== null) {
+      expect(engine.gameState.phase).toBe(GamePhase.Finished);
+    } else {
+      expect(engine.gameState.phase).toBe(GamePhase.Draw);
+      expect(gameOverResult!.winType).toBe("draw");
+    }
+  });
+
+  it("should track wall remaining in client state", async () => {
+    let lastWallRemaining = -1;
+
+    const engine = new GameEngine(StubRuleSet, testPlayers, {
+      onStateUpdate: (idx, state) => {
+        if (idx === 0) {
+          lastWallRemaining = state.wallRemaining;
+        }
+      },
+      botDelayMs: 0,
+    });
+
+    await engine.startGame();
+
+    // Wall should have been depleted during game
+    expect(lastWallRemaining).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("GameEngine - ClientGameState privacy", () => {
+  it("should show correct wallRemaining and wallTailRemaining", () => {
+    const engine = new GameEngine(StubRuleSet, testPlayers);
+    const state = engine.toClientGameState(0);
+
+    expect(typeof state.wallRemaining).toBe("number");
+    expect(typeof state.wallTailRemaining).toBe("number");
+    expect(state.wallRemaining).toBeGreaterThanOrEqual(0);
+    expect(state.wallTailRemaining).toBeGreaterThanOrEqual(0);
+  });
+
+  it("should include melds, discards, and flowers for all players", () => {
+    const engine = new GameEngine(StubRuleSet, testPlayers);
+    const state = engine.toClientGameState(1);
+
+    for (const player of state.players) {
+      expect(Array.isArray(player.melds)).toBe(true);
+      expect(Array.isArray(player.discards)).toBe(true);
+      expect(Array.isArray(player.flowers)).toBe(true);
+    }
+  });
+});

--- a/apps/server/src/game/__tests__/Room.test.ts
+++ b/apps/server/src/game/__tests__/Room.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { registerRuleSet } from "@majiang/shared";
+import { Room, RoomManager, roomManager } from "../Room.js";
+import { StubRuleSet } from "./StubRuleSet.js";
+
+// Register stub ruleset for tests
+registerRuleSet(StubRuleSet);
+
+describe("Room", () => {
+  let room: Room;
+
+  beforeEach(() => {
+    room = new Room("stub");
+  });
+
+  it("should create a room with an id and ruleSetId", () => {
+    expect(room.id).toBeTruthy();
+    expect(room.ruleSetId).toBe("stub");
+    expect(room.state).toBe("waiting");
+    expect(room.players).toHaveLength(0);
+  });
+
+  it("should add a player", () => {
+    const added = room.addPlayer("Alice", "socket-1");
+    expect(added).toBe(true);
+    expect(room.players).toHaveLength(1);
+    expect(room.players[0].name).toBe("Alice");
+    expect(room.players[0].isBot).toBe(false);
+    expect(room.players[0].socketId).toBe("socket-1");
+  });
+
+  it("should not add more than 4 players", () => {
+    room.addPlayer("A", "s1");
+    room.addPlayer("B", "s2");
+    room.addPlayer("C", "s3");
+    room.addPlayer("D", "s4");
+    const added = room.addPlayer("E", "s5");
+    expect(added).toBe(false);
+    expect(room.players).toHaveLength(4);
+  });
+
+  it("should remove a player by socketId", () => {
+    room.addPlayer("Alice", "socket-1");
+    room.addPlayer("Bob", "socket-2");
+    const removed = room.removePlayer("socket-1");
+    expect(removed).toBe(true);
+    expect(room.players).toHaveLength(1);
+    expect(room.players[0].name).toBe("Bob");
+  });
+
+  it("should not remove a player that doesn't exist", () => {
+    room.addPlayer("Alice", "socket-1");
+    const removed = room.removePlayer("nonexistent");
+    expect(removed).toBe(false);
+    expect(room.players).toHaveLength(1);
+  });
+
+  it("should add a bot", () => {
+    const added = room.addBot("Bot-1");
+    expect(added).toBe(true);
+    expect(room.players[0].isBot).toBe(true);
+    expect(room.players[0].name).toBe("Bot-1");
+  });
+
+  it("should know when it can start", () => {
+    expect(room.canStart()).toBe(false);
+    room.addPlayer("A", "s1");
+    room.addPlayer("B", "s2");
+    room.addPlayer("C", "s3");
+    expect(room.canStart()).toBe(false);
+    room.addBot("Bot-1");
+    expect(room.canStart()).toBe(true);
+  });
+
+  it("should start a game and return an engine", () => {
+    room.addPlayer("A", "s1");
+    room.addPlayer("B", "s2");
+    room.addPlayer("C", "s3");
+    room.addBot("Bot-1");
+
+    const engine = room.start();
+    expect(engine).toBeTruthy();
+    expect(room.state).toBe("playing");
+    expect(room.engine).toBe(engine);
+  });
+
+  it("should throw when starting without 4 players", () => {
+    room.addPlayer("A", "s1");
+    expect(() => room.start()).toThrow("Cannot start game");
+  });
+
+  it("should not allow adding players when game is playing", () => {
+    room.addPlayer("A", "s1");
+    room.addPlayer("B", "s2");
+    room.addPlayer("C", "s3");
+    room.addBot("Bot-1");
+    room.start();
+
+    const added = room.addPlayer("E", "s5");
+    expect(added).toBe(false);
+  });
+
+  it("should convert to RoomInfo", () => {
+    room.addPlayer("Alice", "s1");
+    room.addBot("Bot-1");
+
+    const info = room.toRoomInfo();
+    expect(info.id).toBe(room.id);
+    expect(info.ruleSetId).toBe("stub");
+    expect(info.started).toBe(false);
+    expect(info.players).toHaveLength(2);
+    expect(info.players[0].name).toBe("Alice");
+    expect(info.players[0].isBot).toBe(false);
+    expect(info.players[1].name).toBe("Bot-1");
+    expect(info.players[1].isBot).toBe(true);
+  });
+});
+
+describe("RoomManager", () => {
+  let manager: RoomManager;
+
+  beforeEach(() => {
+    manager = new RoomManager();
+  });
+
+  it("should create and retrieve a room", () => {
+    const room = manager.createRoom("stub");
+    expect(room).toBeTruthy();
+    expect(manager.getRoom(room.id)).toBe(room);
+  });
+
+  it("should list all rooms", () => {
+    manager.createRoom("stub");
+    manager.createRoom("stub");
+    expect(manager.listRooms()).toHaveLength(2);
+  });
+
+  it("should remove a room", () => {
+    const room = manager.createRoom("stub");
+    expect(manager.removeRoom(room.id)).toBe(true);
+    expect(manager.getRoom(room.id)).toBeUndefined();
+  });
+
+  it("should return undefined for nonexistent room", () => {
+    expect(manager.getRoom("nonexistent")).toBeUndefined();
+  });
+});

--- a/apps/server/src/game/__tests__/StubRuleSet.ts
+++ b/apps/server/src/game/__tests__/StubRuleSet.ts
@@ -1,0 +1,152 @@
+import type {
+  RuleSet,
+  WinContext,
+  WinResult,
+  ScoreContext,
+  ScoreResult,
+  ActionContext,
+  AvailableActions,
+  DealerContext,
+  DealerResult,
+} from "@majiang/shared";
+import type { Tile, TileInstance, PlayerState } from "@majiang/shared";
+import { Suit, MeldType } from "@majiang/shared";
+
+/**
+ * Minimal RuleSet stub for unit testing the game engine.
+ * Uses only wan 1-9 x4 = 36 tiles. No bonus tiles.
+ * Win condition: hand has exactly 1 pair (2 matching tiles) with rest in melds of 3.
+ * For simplicity in tests, checkWin always returns true.
+ */
+export const StubRuleSet: RuleSet = {
+  id: "stub",
+  name: "Stub Rules",
+  description: "Minimal rule set for testing",
+
+  initialHandSize: 13,
+  hasBonusTiles: false,
+
+  createTilePool(): Tile[] {
+    const tiles: Tile[] = [];
+    const suits = [Suit.Wan, Suit.Bing, Suit.Tiao];
+    for (const suit of suits) {
+      for (let value = 1; value <= 9; value++) {
+        for (let copy = 0; copy < 4; copy++) {
+          tiles.push({
+            kind: "suited",
+            suit,
+            value: value as Tile extends { value: infer V } ? V : never,
+          } as Tile);
+        }
+      }
+    }
+    return tiles; // 108 tiles
+  },
+
+  isBonusTile(_tile: Tile): boolean {
+    return false;
+  },
+
+  checkWin(_player: PlayerState, _winningTile: TileInstance, _context: WinContext): WinResult {
+    return { isWin: true, winType: "stub-win" };
+  },
+
+  calculateScore(_winner: PlayerState, winnerIndex: number, _winResult: WinResult, context: ScoreContext): ScoreResult {
+    // Winner gets +3, each loser pays -1
+    const payments = [0, 0, 0, 0];
+    for (let i = 0; i < 4; i++) {
+      if (i === winnerIndex) {
+        payments[i] = 3;
+      } else {
+        payments[i] = -1;
+      }
+    }
+    return { payments, breakdown: ["stub scoring"] };
+  },
+
+  getResponseActions(player: PlayerState, discardTile: TileInstance, _context: ActionContext): AvailableActions {
+    const result: AvailableActions = {
+      canDraw: false,
+      canDiscard: false,
+      canHu: false,
+      canPeng: false,
+      canMingGang: false,
+      canPass: true,
+      chiOptions: [],
+      anGangOptions: [],
+      buGangOptions: [],
+    };
+
+    // Check peng: player has 2 matching tiles in hand
+    const matchCount = player.hand.filter(
+      (t) => tilesEqual(t.tile, discardTile.tile)
+    ).length;
+
+    if (matchCount >= 2) {
+      result.canPeng = true;
+    }
+    if (matchCount >= 3) {
+      result.canMingGang = true;
+    }
+
+    return result;
+  },
+
+  getPostDrawActions(player: PlayerState, drawnTile: TileInstance, _context: ActionContext): AvailableActions {
+    const result: AvailableActions = {
+      canDraw: false,
+      canDiscard: true,
+      canHu: false,
+      canPeng: false,
+      canMingGang: false,
+      canPass: false,
+      chiOptions: [],
+      anGangOptions: [],
+      buGangOptions: [],
+    };
+
+    // Check anGang: player has 4 of the same tile in hand
+    const tileCounts = new Map<string, TileInstance[]>();
+    for (const t of player.hand) {
+      const key = tileKey(t.tile);
+      const arr = tileCounts.get(key) ?? [];
+      arr.push(t);
+      tileCounts.set(key, arr);
+    }
+    for (const [, group] of tileCounts) {
+      if (group.length === 4) {
+        result.anGangOptions.push(group);
+      }
+    }
+
+    // Check buGang: player has a peng meld and the drawn tile matches
+    for (let i = 0; i < player.melds.length; i++) {
+      const meld = player.melds[i];
+      if (meld.type === MeldType.Peng && tilesEqual(meld.tiles[0].tile, drawnTile.tile)) {
+        result.buGangOptions.push({ tile: drawnTile, meldIndex: i });
+      }
+    }
+
+    return result;
+  },
+
+  getNextDealer(currentDealer: number, winnerIndex: number | null, _context: DealerContext): DealerResult {
+    if (winnerIndex === currentDealer) {
+      return { nextDealer: currentDealer, nextLianZhuang: _context.lianZhuangCount + 1 };
+    }
+    return { nextDealer: (currentDealer + 1) % 4, nextLianZhuang: 0 };
+  },
+};
+
+function tileKey(tile: Tile): string {
+  if (tile.kind === "suited") return `${tile.suit}-${tile.value}`;
+  if (tile.kind === "wind") return `wind-${tile.windType}`;
+  if (tile.kind === "dragon") return `dragon-${tile.dragonType}`;
+  if (tile.kind === "season") return `season-${tile.seasonType}`;
+  if (tile.kind === "plant") return `plant-${tile.plantType}`;
+  return "unknown";
+}
+
+function tilesEqual(a: Tile, b: Tile): boolean {
+  return tileKey(a) === tileKey(b);
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -6,6 +6,7 @@ import { Server } from "socket.io";
 import { getRequestListener } from "@hono/node-server";
 import type { ClientEvents, ServerEvents } from "@majiang/shared";
 import { getAllRuleSets } from "@majiang/shared";
+import { roomManager } from "./game/Room.js";
 
 const app = new Hono();
 
@@ -16,6 +17,29 @@ app.get("/api/health", (c) => c.json({ ok: true }));
 app.get("/api/rulesets", (c) => {
   const sets = getAllRuleSets();
   return c.json(sets.map((s) => ({ id: s.id, name: s.name, description: s.description })));
+});
+
+// Room management endpoints
+app.get("/api/rooms", (c) => {
+  const rooms = roomManager.listRooms();
+  return c.json(rooms.map((r) => r.toRoomInfo()));
+});
+
+app.post("/api/rooms", async (c) => {
+  const body = await c.req.json<{ ruleSetId: string }>();
+  if (!body.ruleSetId) {
+    return c.json({ error: "ruleSetId is required" }, 400);
+  }
+  const room = roomManager.createRoom(body.ruleSetId);
+  return c.json(room.toRoomInfo(), 201);
+});
+
+app.get("/api/rooms/:id", (c) => {
+  const room = roomManager.getRoom(c.req.param("id"));
+  if (!room) {
+    return c.json({ error: "Room not found" }, 404);
+  }
+  return c.json(room.toRoomInfo());
 });
 
 const port = Number(process.env.PORT) || 7702;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.1.0
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
   apps/web:
     dependencies:
@@ -777,8 +780,14 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -803,9 +812,42 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   autoprefixer@10.4.27:
     resolution: {integrity: sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==}
@@ -828,8 +870,20 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   caniuse-lite@1.0.30001782:
     resolution: {integrity: sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -866,6 +920,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
@@ -892,6 +950,9 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -905,6 +966,13 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -961,6 +1029,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1052,6 +1123,9 @@ packages:
   lodash.isarguments@3.1.0:
     resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1090,6 +1164,13 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1154,6 +1235,9 @@ packages:
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   socket.io-adapter@2.5.6:
     resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
 
@@ -1179,8 +1263,17 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
@@ -1192,9 +1285,27 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1221,6 +1332,11 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
 
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
@@ -1261,6 +1377,39 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
@@ -1765,9 +1914,16 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/cors@2.8.19':
     dependencies:
       '@types/node': 22.19.15
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -1799,10 +1955,54 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
+
+  assertion-error@2.0.1: {}
 
   autoprefixer@10.4.27(postcss@8.5.8):
     dependencies:
@@ -1825,7 +2025,19 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  cac@6.7.14: {}
+
   caniuse-lite@1.0.30001782: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
 
   clsx@2.1.1: {}
 
@@ -1847,6 +2059,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  deep-eql@5.0.2: {}
 
   denque@2.1.0: {}
 
@@ -1889,6 +2103,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  es-module-lexer@1.7.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -1950,6 +2166,12 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -1995,6 +2217,8 @@ snapshots:
   jiti@2.6.1: {}
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   jsesc@3.1.0: {}
 
@@ -2053,6 +2277,8 @@ snapshots:
 
   lodash.isarguments@3.1.0: {}
 
+  loupe@3.2.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -2082,6 +2308,10 @@ snapshots:
   node-releases@2.0.36: {}
 
   object-assign@4.1.1: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -2157,6 +2387,8 @@ snapshots:
 
   set-cookie-parser@2.7.2: {}
 
+  siginfo@2.0.0: {}
+
   socket.io-adapter@2.5.6:
     dependencies:
       debug: 4.4.3
@@ -2205,7 +2437,15 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  stackback@0.0.2: {}
+
   standard-as-callback@2.1.0: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   tailwind-merge@3.5.0: {}
 
@@ -2213,10 +2453,20 @@ snapshots:
 
   tapable@2.3.2: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   tslib@2.8.1: {}
 
@@ -2239,6 +2489,27 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite-node@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
@@ -2253,6 +2524,52 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
       tsx: 4.21.0
+
+  vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.15
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   ws@8.18.3: {}
 


### PR DESCRIPTION
Build the core server-side game engine in apps/server/src/.

Room System:
- Room creation with unique ID, ruleSetId, player list
- Join/leave room logic
- Bot player support (addBot)
- Room state management (waiting/playing/finished)

Game State Machine:
- Initialize game: shuffle tiles, deal hands, set dealer
- Turn management: current player draws → discards → others respond
- Action resolution: priority system (hu > peng/gang > chi > pass)
- Bonus tile handling: auto-replace flowers/seasons with wall draws
- Wall management: draw from head, replacement from tail
- Win detection: call RuleSet.checkWin() when hu is claimed
- Score calculation: call RuleSet.calculateScore() on win
- Game end: win or wall exhaustion (draw)
- Dealer rotation via RuleSet.getNextDealer()

Key files to create:
- apps/server/src/game/Room.ts — room management class
- apps/server/src/game/GameEngine.ts — state machine + turn logic
- apps/server/src/game/ActionResolver.ts — action priority + validation

Must use the shared types (GameState, GameAction, PlayerState, etc.) and the registered RuleSet.

Closes #2