### PR TITLE
Fix chained claim bug in GameEngine

### DIFF
--- a/apps/server/src/game/GameEngine.ts
+++ b/apps/server/src/game/GameEngine.ts
@@ -43,8 +43,6 @@ export class GameEngine {
   private actionResolver: ActionResolver | null = null;
   private lianZhuangCount = 0;
   private scores: number[] = [0, 0, 0, 0];
-  private isProcessing = false;
-
   constructor(ruleSet: RuleSet, players: PlayerInfo[], callbacks: GameEngineCallbacks = {}) {
     this.ruleSet = ruleSet;
     this.players = players;
@@ -210,56 +208,9 @@ export class GameEngine {
         const claimResult = await this.handleDiscardResponses(turn, postDrawAction.tile);
 
         if (claimResult) {
-          if (claimResult.action.type === ActionType.Hu) {
-            const won = this.handleHu(claimResult.playerIndex, postDrawAction.tile, false);
-            if (won) return;
-          } else if (claimResult.action.type === ActionType.Peng) {
-            this.executePeng(claimResult.playerIndex, turn, postDrawAction.tile);
-            // After peng, claiming player must discard
-            const pengDiscardAction = await this.waitForPengDiscard(claimResult.playerIndex);
-            this.executeDiscard(claimResult.playerIndex, (pengDiscardAction as { tile: TileInstance }).tile);
-            this.broadcastState();
-
-            const pengClaimResult = await this.handleDiscardResponses(
-              claimResult.playerIndex,
-              (pengDiscardAction as { tile: TileInstance }).tile
-            );
-            if (pengClaimResult) {
-              this.handleClaim(pengClaimResult, claimResult.playerIndex);
-              if (this.gameState.phase !== GamePhase.Playing) return;
-            } else {
-              this.advanceTurn(claimResult.playerIndex);
-            }
-            continue;
-          } else if (claimResult.action.type === ActionType.MingGang) {
-            this.executeMingGang(claimResult.playerIndex, turn, postDrawAction.tile);
-            this.gameState.currentTurn = claimResult.playerIndex;
-            // Gang player draws from tail next turn
-            continue;
-          } else if (claimResult.action.type === ActionType.Chi) {
-            this.executeChi(
-              claimResult.playerIndex,
-              turn,
-              postDrawAction.tile,
-              (claimResult.action as { tiles: [TileInstance, TileInstance] }).tiles
-            );
-            // After chi, claiming player must discard
-            const chiDiscardAction = await this.waitForPengDiscard(claimResult.playerIndex);
-            this.executeDiscard(claimResult.playerIndex, (chiDiscardAction as { tile: TileInstance }).tile);
-            this.broadcastState();
-
-            const chiClaimResult = await this.handleDiscardResponses(
-              claimResult.playerIndex,
-              (chiDiscardAction as { tile: TileInstance }).tile
-            );
-            if (chiClaimResult) {
-              this.handleClaim(chiClaimResult, claimResult.playerIndex);
-              if (this.gameState.phase !== GamePhase.Playing) return;
-            } else {
-              this.advanceTurn(claimResult.playerIndex);
-            }
-            continue;
-          }
+          await this.handleClaimAndDiscard(claimResult, turn, postDrawAction.tile);
+          if (this.gameState.phase !== GamePhase.Playing) return;
+          continue;
         }
 
         // No one claimed, advance to next player
@@ -268,21 +219,53 @@ export class GameEngine {
     }
   }
 
-  private handleClaim(
+  /**
+   * Handle a claim (peng/chi/gang/hu) and the subsequent mandatory discard.
+   * If the discard is itself claimed, recurse to handle the chain.
+   */
+  private async handleClaimAndDiscard(
     claimResult: { playerIndex: number; action: GameAction },
-    discarderIndex: number
-  ): void {
-    const discardTile = this.gameState.lastDiscard?.tile;
-    if (!discardTile) return;
-
+    sourceIndex: number,
+    claimedTile: TileInstance
+  ): Promise<void> {
     if (claimResult.action.type === ActionType.Hu) {
-      this.handleHu(claimResult.playerIndex, discardTile, false);
-    } else if (claimResult.action.type === ActionType.Peng) {
-      this.executePeng(claimResult.playerIndex, discarderIndex, discardTile);
+      this.handleHu(claimResult.playerIndex, claimedTile, false);
+      return;
+    }
+
+    if (claimResult.action.type === ActionType.MingGang) {
+      this.executeMingGang(claimResult.playerIndex, sourceIndex, claimedTile);
       this.gameState.currentTurn = claimResult.playerIndex;
-    } else if (claimResult.action.type === ActionType.MingGang) {
-      this.executeMingGang(claimResult.playerIndex, discarderIndex, discardTile);
-      this.gameState.currentTurn = claimResult.playerIndex;
+      // Gang player draws from tail next turn
+      return;
+    }
+
+    if (claimResult.action.type === ActionType.Peng) {
+      this.executePeng(claimResult.playerIndex, sourceIndex, claimedTile);
+    } else if (claimResult.action.type === ActionType.Chi) {
+      this.executeChi(
+        claimResult.playerIndex,
+        sourceIndex,
+        claimedTile,
+        (claimResult.action as { tiles: [TileInstance, TileInstance] }).tiles
+      );
+    } else {
+      return;
+    }
+
+    // After peng/chi, claiming player must discard
+    const discardAction = await this.waitForPengDiscard(claimResult.playerIndex);
+    const discardedTile = (discardAction as { tile: TileInstance }).tile;
+    this.executeDiscard(claimResult.playerIndex, discardedTile);
+    this.broadcastState();
+
+    // Check if anyone claims the new discard
+    const nextClaimResult = await this.handleDiscardResponses(claimResult.playerIndex, discardedTile);
+    if (nextClaimResult) {
+      // Recurse to handle the chained claim
+      await this.handleClaimAndDiscard(nextClaimResult, claimResult.playerIndex, discardedTile);
+    } else {
+      this.advanceTurn(claimResult.playerIndex);
     }
   }
 

--- a/apps/server/src/game/__tests__/GameEngine.test.ts
+++ b/apps/server/src/game/__tests__/GameEngine.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { GamePhase, registerRuleSet } from "@majiang/shared";
-import type { ClientGameState, AvailableActions } from "@majiang/shared";
+import { describe, it, expect } from "vitest";
+import { GamePhase, Suit, registerRuleSet } from "@majiang/shared";
+import type { ClientGameState, Tile, TileInstance } from "@majiang/shared";
 import { GameEngine } from "../GameEngine.js";
 import type { PlayerInfo, GameEngineCallbacks } from "../GameEngine.js";
 import { StubRuleSet } from "./StubRuleSet.js";
@@ -172,5 +172,84 @@ describe("GameEngine - ClientGameState privacy", () => {
       expect(Array.isArray(player.discards)).toBe(true);
       expect(Array.isArray(player.flowers)).toBe(true);
     }
+  });
+});
+
+describe("GameEngine - chained claims", () => {
+  it("should handle chained peng claims: peng → discard → peng → discard", async () => {
+    const players: PlayerInfo[] = [
+      { name: "P0", isBot: true },
+      { name: "P1", isBot: true },
+      { name: "P2", isBot: true },
+      { name: "P3", isBot: true },
+    ];
+
+    const wan = (value: number, id: number): TileInstance => ({
+      id,
+      tile: { kind: "suited", suit: Suit.Wan, value } as Tile,
+    });
+
+    let gameOverResult: { winnerId: number | null; winType: string } | null = null;
+
+    const engine = new GameEngine(StubRuleSet, players, {
+      botDelayMs: 0,
+      onGameOver: (result) => {
+        gameOverResult = result;
+      },
+    });
+
+    const gs = engine.gameState;
+    gs.dealerIndex = 0;
+    gs.currentTurn = 0;
+    for (let i = 0; i < 4; i++) {
+      gs.players[i].isDealer = i === 0;
+    }
+
+    // Setup: P0 hand is all wan1 so bot always discards wan1.
+    // P1 has 2x wan1 (can peng) + 11x wan2 (after peng, all wan2, always discards wan2).
+    // P2 has 2x wan2 (can peng after P1 discards wan2) + 11x wan3.
+    // P3 has misc tiles (no matching pairs for wan1/wan2/wan3).
+    gs.players[0].hand = Array.from({ length: 13 }, (_, i) => wan(1, 100 + i));
+    gs.players[1].hand = [
+      wan(1, 200), wan(1, 201),
+      ...Array.from({ length: 11 }, (_, i) => wan(2, 202 + i)),
+    ];
+    gs.players[2].hand = [
+      wan(2, 300), wan(2, 301),
+      ...Array.from({ length: 11 }, (_, i) => wan(3, 302 + i)),
+    ];
+    gs.players[3].hand = Array.from({ length: 13 }, (_, i) => wan(4, 400 + i));
+
+    // Wall: first tile is wan1 (P0 draws this, hand stays all wan1, discards wan1).
+    // Remaining tiles let the game finish after the chain.
+    gs.wall = [
+      wan(1, 500),
+      wan(5, 501), wan(5, 502), wan(5, 503), wan(5, 504),
+    ];
+    gs.wallTail = [];
+    gs.phase = GamePhase.Playing;
+
+    await (engine as any).playLoop();
+
+    // Player 1 should have a peng meld of wan1
+    const p1Melds = gs.players[1].melds;
+    expect(p1Melds.length).toBeGreaterThanOrEqual(1);
+    expect(p1Melds[0].tiles.some((t: TileInstance) =>
+      t.tile.kind === "suited" && (t.tile as any).value === 1
+    )).toBe(true);
+
+    // Player 2 should have a peng meld of wan2 (chained claim worked!)
+    const p2Melds = gs.players[2].melds;
+    expect(p2Melds.length).toBeGreaterThanOrEqual(1);
+    expect(p2Melds[0].tiles.some((t: TileInstance) =>
+      t.tile.kind === "suited" && (t.tile as any).value === 2
+    )).toBe(true);
+
+    // Player 2 discarded after peng (went through discard flow, not draw)
+    expect(gs.players[2].discards.length).toBeGreaterThanOrEqual(1);
+
+    // Game should end in a draw (wall runs out)
+    expect(gameOverResult).not.toBeNull();
+    expect(gameOverResult!.winType).toBe("draw");
   });
 });


### PR DESCRIPTION
Fix the depth-2 limitation in claim chains in GameEngine.playLoop.

Bug: After Peng/Chi, the code calls waitForPengDiscard then handleDiscardResponses. If THAT claim leads to another Peng/Chi, handleClaim sets currentTurn but does not await the second claimers mandatory discard. The loop resumes with a draw instead of a discard.

Fix: Refactor the post-claim discard logic (wait for discard -> execute discard -> handle responses) into a reusable method that both playLoop and handleClaim can call recursively.

Test case: Player A discards -> Player B Pengs -> Player B discards -> Player C Pengs -> Player C discards correctly (not draws).

Also remove the unused isProcessing field (dead code).

Closes #9