### PR TITLE
Socket-IO event integration

### DIFF
--- a/apps/web/src/hooks/useSocket.ts
+++ b/apps/web/src/hooks/useSocket.ts
@@ -11,7 +11,6 @@ const SOCKET_URL = import.meta.env.DEV
 
 export function useSocket() {
   const socketRef = useRef<GameSocket | null>(null);
-  const store = useGameStore();
 
   useEffect(() => {
     const socket: GameSocket = io(SOCKET_URL, {
@@ -21,30 +20,45 @@ export function useSocket() {
 
     socketRef.current = socket;
 
+    const store = useGameStore.getState();
+    store.setSocket(socket);
+
     socket.on("connect", () => {
-      store.setConnected(true);
+      useGameStore.getState().setConnected(true);
     });
 
     socket.on("disconnect", () => {
-      store.setConnected(false);
+      useGameStore.getState().setConnected(false);
     });
 
     socket.on("gameStateUpdate", (state) => {
-      store.setGameState(state);
+      useGameStore.getState().setGameState(state);
     });
 
     socket.on("actionRequired", (actions) => {
-      store.setAvailableActions(actions);
+      useGameStore.getState().setAvailableActions(actions);
     });
 
     socket.on("gameOver", (result) => {
-      // Handle game over — could be a modal or state update
       console.log("Game over:", result);
+    });
+
+    socket.on("roomUpdate", (room) => {
+      useGameStore.getState().setRoomInfo(room);
+    });
+
+    socket.on("actionError", (error) => {
+      useGameStore.getState().setErrorMessage(error.message);
+    });
+
+    socket.on("error", (msg) => {
+      useGameStore.getState().setErrorMessage(msg);
     });
 
     return () => {
       socket.disconnect();
       socketRef.current = null;
+      useGameStore.getState().setSocket(null);
     };
   }, []);
 

--- a/apps/web/src/stores/gameStore.ts
+++ b/apps/web/src/stores/gameStore.ts
@@ -1,11 +1,25 @@
 import { create } from "zustand";
-import type { ClientGameState, AvailableActions } from "@majiang/shared";
+import type {
+  ClientGameState,
+  AvailableActions,
+  RoomInfo,
+  GameAction,
+} from "@majiang/shared";
+import type { Socket } from "socket.io-client";
+import type { ClientEvents, ServerEvents } from "@majiang/shared";
+
+type GameSocket = Socket<ServerEvents, ClientEvents>;
 
 interface GameStore {
   // Connection
   connected: boolean;
   roomId: string | null;
   myIndex: number;
+
+  // Room & player
+  roomInfo: RoomInfo | null;
+  playerName: string;
+  errorMessage: string | null;
 
   // Game state
   gameState: ClientGameState | null;
@@ -14,34 +28,96 @@ interface GameStore {
   // UI state
   selectedTileId: number | null;
 
-  // Actions
+  // Socket ref (not serializable, but fine for zustand)
+  socket: GameSocket | null;
+
+  // Actions — state setters
   setConnected: (connected: boolean) => void;
   setRoom: (roomId: string, myIndex: number) => void;
   setGameState: (state: ClientGameState) => void;
   setAvailableActions: (actions: AvailableActions | null) => void;
+  setRoomInfo: (room: RoomInfo) => void;
+  setErrorMessage: (msg: string | null) => void;
+  setPlayerName: (name: string) => void;
   selectTile: (id: number | null) => void;
+  setSocket: (socket: GameSocket | null) => void;
+
+  // Actions — socket emitters
+  createRoom: (playerName: string, ruleSetId: string) => void;
+  joinRoom: (roomId: string, playerName: string) => void;
+  addBot: (name: string) => void;
+  startGame: () => void;
+  submitAction: (action: GameAction) => void;
+
   reset: () => void;
 }
 
-export const useGameStore = create<GameStore>((set) => ({
+const initialState = {
   connected: false,
   roomId: null,
   myIndex: 0,
+  roomInfo: null,
+  playerName: "",
+  errorMessage: null,
   gameState: null,
   availableActions: null,
   selectedTileId: null,
+  socket: null,
+};
+
+export const useGameStore = create<GameStore>((set, get) => ({
+  ...initialState,
 
   setConnected: (connected) => set({ connected }),
   setRoom: (roomId, myIndex) => set({ roomId, myIndex }),
   setGameState: (gameState) => set({ gameState }),
   setAvailableActions: (actions) => set({ availableActions: actions }),
+  setRoomInfo: (room) => set({ roomInfo: room }),
+  setErrorMessage: (msg) => set({ errorMessage: msg }),
+  setPlayerName: (name) => set({ playerName: name }),
   selectTile: (id) => set({ selectedTileId: id }),
-  reset: () => set({
-    connected: false,
-    roomId: null,
-    myIndex: 0,
-    gameState: null,
-    availableActions: null,
-    selectedTileId: null,
-  }),
+  setSocket: (socket) => set({ socket }),
+
+  createRoom: (playerName, ruleSetId) => {
+    const { socket } = get();
+    if (!socket) return;
+    set({ playerName });
+    socket.emit("createRoom", { playerName, ruleSetId }, (room) => {
+      set({ roomInfo: room, roomId: room.id });
+    });
+  },
+
+  joinRoom: (roomId, playerName) => {
+    const { socket } = get();
+    if (!socket) return;
+    set({ playerName });
+    socket.emit("joinRoom", { roomId, playerName }, (room) => {
+      if (room) {
+        set({ roomInfo: room, roomId: room.id });
+      } else {
+        set({ errorMessage: "Failed to join room" });
+      }
+    });
+  },
+
+  addBot: (name) => {
+    const { socket } = get();
+    if (!socket) return;
+    socket.emit("addBot", { name });
+  },
+
+  startGame: () => {
+    const { socket } = get();
+    if (!socket) return;
+    socket.emit("startGame");
+  },
+
+  submitAction: (action) => {
+    const { socket } = get();
+    if (!socket) return;
+    socket.emit("playerAction", action);
+    set({ availableActions: null });
+  },
+
+  reset: () => set({ ...initialState }),
 }));


### PR DESCRIPTION
Wire up Socket.IO events between server and client to enable real-time gameplay.

Server side (apps/server/src/index.ts or new socket handler file):
- Handle ClientEvents: createRoom, joinRoom, addBot, startGame, playerAction
- Emit ServerEvents: gameStateUpdate, actionRequired, gameOver, actionError, roomUpdate
- On createRoom: create Room instance, join socket to room, emit roomUpdate
- On joinRoom: add player to room, emit roomUpdate to all
- On startGame: init GameEngine, deal tiles, emit gameStateUpdate to each player (filtered via ClientGameState)
- On playerAction: validate action, update game state, emit updates
- Ensure ClientGameState hides other players hands (only myIndex hand visible)

Client side (apps/web/src/hooks/useSocket.ts):
- Emit createRoom/joinRoom/startGame/playerAction from UI actions
- Handle gameStateUpdate to update zustand store
- Handle actionRequired to update availableActions in store
- Handle roomUpdate to update room info
- Handle gameOver to show result
- Handle actionError to show error toast

Update gameStore.ts:
- Add roomInfo state
- Add socket action dispatchers
- Connect store updates to actual socket events instead of mock data

Closes #5