### PR TITLE
Socket-IO event wiring

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -7,6 +7,7 @@ import { getRequestListener } from "@hono/node-server";
 import type { ClientEvents, ServerEvents } from "@majiang/shared";
 import { getAllRuleSets } from "@majiang/shared";
 import { roomManager } from "./game/Room.js";
+import { registerSocketHandlers } from "./socketHandlers.js";
 
 const app = new Hono();
 
@@ -52,13 +53,7 @@ const io = new Server<ClientEvents, ServerEvents>(httpServer, {
   path: "/socket.io/",
 });
 
-io.on("connection", (socket) => {
-  console.log(`Client connected: ${socket.id}`);
-
-  socket.on("disconnect", () => {
-    console.log(`Client disconnected: ${socket.id}`);
-  });
-});
+registerSocketHandlers(io);
 
 httpServer.listen(port, "0.0.0.0", () => {
   console.log(`Server running on port ${port}`);

--- a/apps/server/src/socketHandlers.ts
+++ b/apps/server/src/socketHandlers.ts
@@ -1,0 +1,183 @@
+import type { Server, Socket } from "socket.io";
+import type { ClientEvents, ServerEvents, GameAction } from "@majiang/shared";
+import type { GameEngineCallbacks } from "./game/GameEngine.js";
+import { roomManager } from "./game/Room.js";
+import type { Room } from "./game/Room.js";
+
+/** Track which socket belongs to which room and player seat */
+const socketToRoom = new Map<string, { roomId: string; playerIndex: number }>();
+
+export function registerSocketHandlers(
+  io: Server<ClientEvents, ServerEvents>
+): void {
+  io.on("connection", (socket: Socket<ClientEvents, ServerEvents>) => {
+    console.log(`Client connected: ${socket.id}`);
+
+    socket.on("createRoom", ({ playerName, ruleSetId }, cb) => {
+      try {
+        const room = roomManager.createRoom(ruleSetId);
+        const added = room.addPlayer(playerName, socket.id);
+        if (!added) {
+          socket.emit("actionError", { message: "Failed to join room", code: "JOIN_FAILED" });
+          return;
+        }
+        socket.join(room.id);
+        const playerIndex = room.players.length - 1;
+        socketToRoom.set(socket.id, { roomId: room.id, playerIndex });
+        const roomInfo = room.toRoomInfo();
+        cb(roomInfo);
+        socket.emit("roomUpdate", roomInfo);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        socket.emit("actionError", { message, code: "CREATE_ROOM_ERROR" });
+      }
+    });
+
+    socket.on("joinRoom", ({ roomId, playerName }, cb) => {
+      try {
+        const room = roomManager.getRoom(roomId);
+        if (!room) {
+          cb(null);
+          return;
+        }
+        const added = room.addPlayer(playerName, socket.id);
+        if (!added) {
+          socket.emit("actionError", { message: "Room is full or game already started", code: "JOIN_FAILED" });
+          cb(null);
+          return;
+        }
+        socket.join(roomId);
+        const playerIndex = room.players.length - 1;
+        socketToRoom.set(socket.id, { roomId, playerIndex });
+        const roomInfo = room.toRoomInfo();
+        cb(roomInfo);
+        io.to(roomId).emit("roomUpdate", roomInfo);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        socket.emit("actionError", { message, code: "JOIN_ROOM_ERROR" });
+        cb(null);
+      }
+    });
+
+    socket.on("addBot", ({ name }) => {
+      try {
+        const mapping = socketToRoom.get(socket.id);
+        if (!mapping) {
+          socket.emit("actionError", { message: "Not in a room", code: "NOT_IN_ROOM" });
+          return;
+        }
+        const room = roomManager.getRoom(mapping.roomId);
+        if (!room) {
+          socket.emit("actionError", { message: "Room not found", code: "ROOM_NOT_FOUND" });
+          return;
+        }
+        const added = room.addBot(name);
+        if (!added) {
+          socket.emit("actionError", { message: "Cannot add bot", code: "ADD_BOT_FAILED" });
+          return;
+        }
+        io.to(room.id).emit("roomUpdate", room.toRoomInfo());
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        socket.emit("actionError", { message, code: "ADD_BOT_ERROR" });
+      }
+    });
+
+    socket.on("startGame", () => {
+      try {
+        const mapping = socketToRoom.get(socket.id);
+        if (!mapping) {
+          socket.emit("actionError", { message: "Not in a room", code: "NOT_IN_ROOM" });
+          return;
+        }
+        const room = roomManager.getRoom(mapping.roomId);
+        if (!room) {
+          socket.emit("actionError", { message: "Room not found", code: "ROOM_NOT_FOUND" });
+          return;
+        }
+        if (!room.canStart()) {
+          socket.emit("actionError", { message: "Cannot start: need exactly 4 players", code: "CANNOT_START" });
+          return;
+        }
+
+        const callbacks = buildCallbacks(io, room);
+        const engine = room.start(callbacks);
+
+        // Run game loop asynchronously — don't await
+        engine.startGame().catch((err) => {
+          const message = err instanceof Error ? err.message : "Game error";
+          io.to(room.id).emit("error", message);
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        socket.emit("actionError", { message, code: "START_GAME_ERROR" });
+      }
+    });
+
+    socket.on("playerAction", (action: GameAction) => {
+      try {
+        const mapping = socketToRoom.get(socket.id);
+        if (!mapping) {
+          socket.emit("actionError", { message: "Not in a room", code: "NOT_IN_ROOM" });
+          return;
+        }
+        const room = roomManager.getRoom(mapping.roomId);
+        if (!room || !room.engine) {
+          socket.emit("actionError", { message: "Game not in progress", code: "NO_GAME" });
+          return;
+        }
+        room.engine.submitAction(mapping.playerIndex, action);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        socket.emit("actionError", { message, code: "ACTION_ERROR" });
+      }
+    });
+
+    socket.on("disconnect", () => {
+      console.log(`Client disconnected: ${socket.id}`);
+      const mapping = socketToRoom.get(socket.id);
+      if (!mapping) return;
+
+      const room = roomManager.getRoom(mapping.roomId);
+      socketToRoom.delete(socket.id);
+
+      if (!room) return;
+
+      if (room.state === "waiting") {
+        room.removePlayer(socket.id);
+        io.to(room.id).emit("roomUpdate", room.toRoomInfo());
+      } else if (room.state === "playing") {
+        // Mark player as disconnected (clear socketId so bot logic can take over)
+        const player = room.players[mapping.playerIndex];
+        if (player) {
+          player.socketId = undefined;
+        }
+        io.to(room.id).emit("roomUpdate", room.toRoomInfo());
+      }
+    });
+  });
+}
+
+function buildCallbacks(
+  io: Server<ClientEvents, ServerEvents>,
+  room: Room
+): GameEngineCallbacks {
+  return {
+    onStateUpdate: (playerIndex, state) => {
+      const player = room.players[playerIndex];
+      if (player?.socketId) {
+        io.to(player.socketId).emit("gameStateUpdate", state);
+      }
+    },
+    onActionRequired: (playerIndex, actions) => {
+      const player = room.players[playerIndex];
+      if (player?.socketId) {
+        io.to(player.socketId).emit("actionRequired", actions);
+      }
+    },
+    onGameOver: (result) => {
+      io.to(room.id).emit("gameOver", result);
+      room.state = "finished";
+    },
+  };
+}


### PR DESCRIPTION
Wire up Socket.IO event handlers to bridge the GameEngine with frontend clients.

Server side (apps/server/src/index.ts or new socket handler file):
- Handle ClientEvents from events.ts:
  - createRoom: create Room via roomManager, join socket to room, emit roomUpdate
  - joinRoom: add player to room, emit roomUpdate to all in room
  - addBot: add bot to room, emit roomUpdate
  - startGame: call room.start() with callbacks that emit to sockets, emit gameStateUpdate per player
  - playerAction: call engine.submitAction(), let engine callbacks handle response
- Wire GameEngineCallbacks to Socket.IO emissions:
  - onStateUpdate(playerIndex, state) -> emit gameStateUpdate to that player socket
  - onActionRequired(playerIndex, actions) -> emit actionRequired to that player socket
  - onGameOver(result) -> emit gameOver to all in room
- Track socket-to-player mapping (socketId -> roomId + playerIndex)
- Handle disconnect: remove from room if waiting, mark as disconnected if playing

This is approx 150 lines of socket handler code. The GameEngine and Room classes from ticket #2 do all the heavy lifting — this ticket just wires events.

Closes #10