### PR TITLE
GameEngine golden tile phase integration

### DIFF
--- a/apps/server/src/game/GameEngine.ts
+++ b/apps/server/src/game/GameEngine.ts
@@ -105,6 +105,8 @@ export class GameEngine {
       lastDiscard: gs.lastDiscard,
       ruleSetId: gs.ruleSetId,
       myIndex: playerIndex,
+      goldenTile: gs.goldenTile,
+      flippedTile: gs.flippedTile,
     };
   }
 
@@ -149,6 +151,20 @@ export class GameEngine {
     if (this.ruleSet.hasBonusTiles) {
       for (let i = 0; i < 4; i++) {
         this.replaceBonusTiles(i);
+      }
+    }
+
+    // Reveal golden tile (if RuleSet supports it)
+    if (this.ruleSet.determineGoldenTile) {
+      let flipped = this.drawFromWall();
+      // Skip bonus tiles — put them back in tail and draw again
+      while (flipped && this.ruleSet.isBonusTile(flipped.tile)) {
+        this.gameState.wallTail.push(flipped);
+        flipped = this.drawFromWall();
+      }
+      if (flipped) {
+        this.gameState.flippedTile = flipped.tile;
+        this.gameState.goldenTile = this.ruleSet.determineGoldenTile(flipped.tile);
       }
     }
 
@@ -526,6 +542,7 @@ export class GameEngine {
       isFirstAction: player.discards.length === 0 && player.melds.length === 0,
       isDealer: player.isDealer,
       isRobbingKong: false,
+      extra: { goldenTile: this.gameState.goldenTile },
     });
 
     if (!winResult.isWin) return false;
@@ -537,6 +554,7 @@ export class GameEngine {
       {
         isSelfDraw,
         discarderIndex: isSelfDraw ? null : this.gameState.lastDiscard?.playerIndex ?? null,
+        extra: { goldenTile: this.gameState.goldenTile, dealerIndex: this.gameState.dealerIndex },
       }
     );
 

--- a/apps/server/src/game/__tests__/GameEngine.test.ts
+++ b/apps/server/src/game/__tests__/GameEngine.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { GamePhase, Suit, registerRuleSet } from "@majiang/shared";
-import type { ClientGameState, Tile, TileInstance } from "@majiang/shared";
+import { GamePhase, Suit, registerRuleSet, fuzhouRuleSet } from "@majiang/shared";
+import type { ClientGameState, Tile, TileInstance, RuleSet } from "@majiang/shared";
 import { GameEngine } from "../GameEngine.js";
 import type { PlayerInfo, GameEngineCallbacks } from "../GameEngine.js";
 import { StubRuleSet } from "./StubRuleSet.js";
@@ -251,5 +251,111 @@ describe("GameEngine - chained claims", () => {
     // Game should end in a draw (wall runs out)
     expect(gameOverResult).not.toBeNull();
     expect(gameOverResult!.winType).toBe("draw");
+  });
+});
+
+describe("GameEngine - golden tile", () => {
+  const goldenPlayers: PlayerInfo[] = [
+    { name: "P0", isBot: true },
+    { name: "P1", isBot: true },
+    { name: "P2", isBot: true },
+    { name: "P3", isBot: true },
+  ];
+
+  it("should reveal golden tile during deal when RuleSet supports it", async () => {
+    const engine = new GameEngine(fuzhouRuleSet, goldenPlayers, { botDelayMs: 0 });
+    await engine.startGame();
+
+    // After deal, goldenTile and flippedTile should be set
+    expect(engine.gameState.goldenTile).toBeDefined();
+    expect(engine.gameState.flippedTile).toBeDefined();
+  });
+
+  it("should not reveal golden tile for RuleSets without determineGoldenTile", async () => {
+    const engine = new GameEngine(StubRuleSet, goldenPlayers, { botDelayMs: 0 });
+    await engine.startGame();
+
+    // StubRuleSet has no determineGoldenTile, so these should be undefined
+    expect(engine.gameState.goldenTile).toBeUndefined();
+    expect(engine.gameState.flippedTile).toBeUndefined();
+  });
+
+  it("should include goldenTile and flippedTile in ClientGameState", async () => {
+    const states: ClientGameState[] = [];
+    const engine = new GameEngine(fuzhouRuleSet, goldenPlayers, {
+      botDelayMs: 0,
+      onStateUpdate: (_idx, state) => {
+        if (_idx === 0) states.push(state);
+      },
+    });
+    await engine.startGame();
+
+    // Find a state after dealing (Playing phase)
+    const playingState = states.find((s) => s.phase === GamePhase.Playing);
+    expect(playingState).toBeDefined();
+    expect(playingState!.goldenTile).toBeDefined();
+    expect(playingState!.flippedTile).toBeDefined();
+  });
+
+  it("should skip bonus tiles when flipping for golden tile", () => {
+    // Create a RuleSet stub that has determineGoldenTile and bonus tiles
+    const ruleSetWithGolden: RuleSet = {
+      ...StubRuleSet,
+      id: "stub-golden",
+      hasBonusTiles: true,
+      isBonusTile(tile: Tile): boolean {
+        return tile.kind === "season" || tile.kind === "plant";
+      },
+      determineGoldenTile(flippedTile: Tile): Tile {
+        // Simple: just return the tile itself as the golden tile
+        return flippedTile;
+      },
+    };
+
+    const engine = new GameEngine(ruleSetWithGolden, goldenPlayers);
+    const gs = engine.gameState;
+
+    // Pre-set hands so deal() doesn't need to deal from wall
+    for (const p of gs.players) {
+      p.hand = Array.from({ length: 13 }, (_, i) => ({
+        id: 1000 + i,
+        tile: { kind: "suited", suit: Suit.Wan, value: 1 } as Tile,
+      }));
+    }
+
+    // Override shuffle to be a no-op so we control exact wall order
+    (engine as any).shuffle = () => {};
+
+    // Set up wall: bonus tiles at front, then a suited tile for the golden tile flip
+    // deal() will re-create the wall from createTilePool, so we override createTilePool too
+    // Actually simpler: just override the deal internals by monkey-patching
+    // Let's instead directly test the golden tile reveal logic post-deal
+    // by setting up the wall manually and calling deal()
+
+    // Override createTilePool to return controlled tiles:
+    // 52 suited tiles for hands (4 players x 13) + 2 bonus + 1 suited for golden flip
+    const controlledTiles: Tile[] = [];
+    // 52 wan-1 tiles for dealing
+    for (let i = 0; i < 52; i++) {
+      controlledTiles.push({ kind: "suited", suit: Suit.Wan, value: 1 } as Tile);
+    }
+    // These will end up in the wall after dealing:
+    // 2 bonus tiles followed by suited wan-5
+    controlledTiles.push({ kind: "season", seasonType: "spring" });
+    controlledTiles.push({ kind: "season", seasonType: "summer" });
+    controlledTiles.push({ kind: "suited", suit: Suit.Wan, value: 5 } as Tile);
+    // A few more tiles for the wall tail
+    for (let i = 0; i < 14; i++) {
+      controlledTiles.push({ kind: "suited", suit: Suit.Wan, value: 2 } as Tile);
+    }
+
+    ruleSetWithGolden.createTilePool = () => controlledTiles;
+
+    (engine as any).deal();
+
+    // The bonus tiles should have been skipped
+    // The flipped tile should be wan-5
+    expect(gs.flippedTile).toEqual({ kind: "suited", suit: Suit.Wan, value: 5 });
+    expect(gs.goldenTile).toEqual({ kind: "suited", suit: Suit.Wan, value: 5 });
   });
 });

--- a/packages/shared/src/rules/fuzhou.ts
+++ b/packages/shared/src/rules/fuzhou.ts
@@ -515,6 +515,10 @@ export const fuzhouRuleSet: RuleSet = {
     return isBonusTileGuard(tile);
   },
 
+  determineGoldenTile(flippedTile: Tile): Tile {
+    return determineGoldenTile(flippedTile);
+  },
+
   checkWin(player: PlayerState, winningTile: TileInstance, context: WinContext): WinResult {
     const goldenTile = (context.extra?.goldenTile as Tile) ?? null;
     const allHandTiles = [...player.hand, winningTile];

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -1,6 +1,6 @@
 import type { GameState, PlayerState } from "./game.js";
 import type { AvailableActions } from "./rules.js";
-import type { TileInstance } from "./tile.js";
+import type { Tile, TileInstance } from "./tile.js";
 
 /** Client game state — hides other players' hands */
 export interface ClientGameState {
@@ -13,6 +13,8 @@ export interface ClientGameState {
   lastDiscard: GameState["lastDiscard"];
   ruleSetId: string;
   myIndex: number;
+  goldenTile?: Tile;
+  flippedTile?: Tile;
 }
 
 export interface ClientPlayerState {

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -1,4 +1,4 @@
-import type { TileInstance } from "./tile.js";
+import type { Tile, TileInstance } from "./tile.js";
 
 export enum GamePhase {
   Waiting = "waiting",
@@ -42,4 +42,6 @@ export interface GameState {
   dealerIndex: number;
   lastDiscard: { tile: TileInstance; playerIndex: number } | null;
   ruleSetId: string;
+  goldenTile?: Tile;
+  flippedTile?: Tile;
 }

--- a/packages/shared/src/types/rules.ts
+++ b/packages/shared/src/types/rules.ts
@@ -34,6 +34,9 @@ export interface RuleSet {
   /** Get available actions after drawing a tile */
   getPostDrawActions(player: PlayerState, drawnTile: TileInstance, context: ActionContext): AvailableActions;
 
+  /** Determine the golden (wildcard) tile from the flipped indicator tile. Only needed for variants that use golden tiles. */
+  determineGoldenTile?(flippedTile: Tile): Tile;
+
   /** Determine next dealer after a round */
   getNextDealer(currentDealer: number, winnerIndex: number | null, context: DealerContext): DealerResult;
 }


### PR DESCRIPTION
Wire the golden tile (金牌) reveal into GameEngine after dealing.

The Fuzhou RuleSet (ticket #1) already exports determineGoldenTile() and reads goldenTile from context.extra in checkWin/calculateScore. The GameEngine needs to:

1. After dealing + flower replacement, flip a tile from the wall to determine the golden tile
2. Call determineGoldenTile(flippedTile) to get the actual wildcard tile
3. Store goldenTile on the GameState (add optional field or use existing structure)
4. Pass goldenTile through WinContext.extra and ScoreContext.extra when calling ruleSet.checkWin() and ruleSet.calculateScore()
5. Pass goldenTile on gameState when calling getResponseActions/getPostDrawActions so the RuleSet can block claims on golden tile discards
6. Include goldenTile info in ClientGameState so the UI can display it
7. Handle the case where flipped tile is a bonus tile (skip and flip next)

Key files:
- apps/server/src/game/GameEngine.ts — add golden tile reveal in deal(), pass through all RuleSet calls
- packages/shared/src/types/events.ts — may need to add goldenTile to ClientGameState
- packages/shared/src/types/game.ts — may need to add optional goldenTile to GameState

The Fuzhou RuleSet already handles goldenTile in all its methods via context.extra — this ticket just ensures the engine provides it.

Closes #13