### PR TITLE
Wire ScoreBoard and RoundInfo to game state

### DIFF
--- a/apps/web/src/pages/GamePage.tsx
+++ b/apps/web/src/pages/GamePage.tsx
@@ -8,6 +8,7 @@ import RoundInfo from "../components/sidebar/RoundInfo.js";
 import ChatPanel from "../components/chat/ChatPanel.js";
 import type { ActionOption } from "../components/game/ActionBubbles.js";
 import { useTileTracker } from "../hooks/useTileTracker.js";
+import { useGameStore } from "../stores/gameStore.js";
 
 const MOCK_SCORES = [
   { name: "下家", score: 32 },
@@ -46,6 +47,7 @@ const MOCK_CHAT = [
 
 export default function GamePage() {
   const trackerSections = useTileTracker();
+  const gameState = useGameStore((s) => s.gameState);
   const [selectedTile, setSelectedTile] = useState<number | null>(null);
   const [showActions, setShowActions] = useState(true);
   const [chatMessages, setChatMessages] = useState(MOCK_CHAT);
@@ -103,11 +105,21 @@ export default function GamePage() {
         {/* Left sidebar */}
         <div className="w-52 shrink-0 flex flex-col gap-1.5 bg-white/[.02] border border-white/[.07] rounded-xl p-2 overflow-y-auto">
           {trackerSections && <TileTracker sections={trackerSections} />}
-          <ScoreBoard scores={MOCK_SCORES} />
+          <ScoreBoard
+            scores={
+              gameState
+                ? gameState.players.map((p, i) => ({
+                    name: p.name,
+                    score: 0,
+                    isMe: i === gameState.myIndex,
+                  }))
+                : MOCK_SCORES
+            }
+          />
           <RoundInfo
             roundLabel="东风 · 第一局"
-            dealerName="下家"
-            wallRemaining={120}
+            dealerName={gameState ? gameState.players[gameState.dealerIndex].name : "下家"}
+            wallRemaining={gameState ? gameState.wallRemaining : 120}
           />
         </div>
 


### PR DESCRIPTION
Wire ScoreBoard and RoundInfo sidebar components to real gameStore data instead of mock constants.

ScoreBoard: show player names from gameState.players with scores (0 placeholder if not in ClientGameState yet, or derive from game over results if available).

RoundInfo: show round label (wind + round number), dealer name from gameState.players[dealerIndex], wallRemaining from gameState.

Create hooks or derive inline in GamePage. Both components already exist with working prop interfaces — just need real data instead of MOCK_SCORES and hardcoded strings.

Closes #25