### PR TITLE
Bot AI full game validation test

### DIFF
--- a/apps/server/src/game/__tests__/botGame.test.ts
+++ b/apps/server/src/game/__tests__/botGame.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { GamePhase, registerRuleSet, fuzhouRuleSet } from "@majiang/shared";
+import { GameEngine } from "../GameEngine.js";
+import type { PlayerInfo } from "../GameEngine.js";
+
+registerRuleSet(fuzhouRuleSet);
+
+const botPlayers: PlayerInfo[] = [
+  { name: "Bot-A", isBot: true },
+  { name: "Bot-B", isBot: true },
+  { name: "Bot-C", isBot: true },
+  { name: "Bot-D", isBot: true },
+];
+
+describe("Bot AI full game validation", () => {
+  for (let gameNum = 1; gameNum <= 10; gameNum++) {
+    it(`game ${gameNum}: completes without errors`, async () => {
+      let gameOverResult: {
+        winnerId: number | null;
+        winType: string;
+        scores: number[];
+      } | null = null;
+
+      const engine = new GameEngine(fuzhouRuleSet, botPlayers, {
+        botDelayMs: 0,
+        onGameOver: (result) => {
+          gameOverResult = result;
+        },
+      });
+
+      await engine.startGame();
+
+      // Game should have ended
+      expect(gameOverResult).not.toBeNull();
+      expect(gameOverResult!.scores).toHaveLength(4);
+
+      // Scores should be zero-sum
+      const totalScore = gameOverResult!.scores.reduce((a, b) => a + b, 0);
+      expect(totalScore).toBe(0);
+
+      // Golden tile should have been set (Fuzhou feature)
+      expect(engine.gameState.goldenTile).toBeDefined();
+      expect(engine.gameState.flippedTile).toBeDefined();
+
+      // Phase should be Finished or Draw
+      expect([GamePhase.Finished, GamePhase.Draw]).toContain(
+        engine.gameState.phase,
+      );
+    }, 30000);
+  }
+});


### PR DESCRIPTION
Run a full automated game with 4 bots using the Fuzhou ruleset and verify the complete flow works without errors.

Write a test that:
1. Creates a game with 4 bot players using the Fuzhou ruleset
2. Runs the full game loop to completion (win or draw)
3. Verifies golden tile was revealed
4. Verifies all game phases executed correctly (Dealing -> Playing -> Finished/Draw)
5. Verifies scores are zero-sum
6. Verifies no errors thrown during the game
7. Run multiple games (5-10) to catch intermittent issues
8. Log any unexpected states or errors

This is different from the e2e socket test (#12) — this tests the GameEngine directly without socket overhead, focusing on game logic correctness across multiple full games.

Key files:
- apps/server/src/game/__tests__/botGame.test.ts
- Reference: apps/server/src/game/GameEngine.ts
- Reference: packages/shared/src/rules/fuzhou.ts

Closes #33