### PR TITLE
Game over modal and live score display

### DIFF
--- a/apps/web/src/components/game/RoundResultModal.tsx
+++ b/apps/web/src/components/game/RoundResultModal.tsx
@@ -1,0 +1,132 @@
+import type { RoundResult } from "../../stores/gameStore.js";
+
+interface Player {
+  name: string;
+}
+
+interface RoundResultModalProps {
+  result: RoundResult;
+  players: Player[];
+  onClose: () => void;
+}
+
+export default function RoundResultModal({
+  result,
+  players,
+  onClose,
+}: RoundResultModalProps) {
+  const isWin = result.winnerId !== null;
+  const winnerName =
+    isWin && result.winnerId !== null ? players[result.winnerId]?.name : null;
+
+  return (
+    <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="bg-neutral-900 border border-neutral-700 rounded-xl w-full max-w-md mx-4 p-6 shadow-2xl">
+        {/* Header */}
+        {isWin ? (
+          <div className="text-center mb-4">
+            <h2 className="text-2xl font-bold text-amber-400">
+              {winnerName} 胡牌!
+            </h2>
+            {result.winType && (
+              <p className="text-sm text-amber-300/70 mt-1">
+                {result.winType}
+              </p>
+            )}
+          </div>
+        ) : (
+          <div className="text-center mb-4">
+            <h2 className="text-2xl font-bold text-neutral-300">流局</h2>
+          </div>
+        )}
+
+        {/* Breakdown */}
+        {result.breakdown.length > 0 && (
+          <div className="mb-4">
+            <h3 className="text-xs font-semibold text-white/50 uppercase tracking-wider mb-2">
+              计分明细
+            </h3>
+            <div className="space-y-1">
+              {result.breakdown.map((line, i) => (
+                <p key={i} className="text-sm text-white/70">
+                  {line}
+                </p>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Payments */}
+        <div className="mb-4">
+          <h3 className="text-xs font-semibold text-white/50 uppercase tracking-wider mb-2">
+            收支
+          </h3>
+          <div className="space-y-1">
+            {players.map((p, i) => {
+              const payment = result.payments[i] ?? 0;
+              return (
+                <div
+                  key={i}
+                  className="flex justify-between text-sm"
+                >
+                  <span className="text-white/80">{p.name}</span>
+                  <span
+                    className={
+                      payment > 0
+                        ? "text-green-400"
+                        : payment < 0
+                          ? "text-red-400"
+                          : "text-white/50"
+                    }
+                  >
+                    {payment > 0 ? "+" : ""}
+                    {payment}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Total scores */}
+        <div className="mb-6">
+          <h3 className="text-xs font-semibold text-white/50 uppercase tracking-wider mb-2">
+            总分
+          </h3>
+          <div className="space-y-1">
+            {players.map((p, i) => {
+              const score = result.scores[i] ?? 0;
+              return (
+                <div
+                  key={i}
+                  className="flex justify-between text-sm"
+                >
+                  <span className="text-white/80">{p.name}</span>
+                  <span
+                    className={
+                      score > 0
+                        ? "text-green-400"
+                        : score < 0
+                          ? "text-red-400"
+                          : "text-white/50"
+                    }
+                  >
+                    {score}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Back to lobby button */}
+        <button
+          onClick={onClose}
+          className="w-full py-2.5 rounded-lg bg-amber-600 hover:bg-amber-500 text-white font-medium transition-colors cursor-pointer"
+        >
+          返回大厅
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useGameData.ts
+++ b/apps/web/src/hooks/useGameData.ts
@@ -130,10 +130,11 @@ export function useGameData() {
           }
         : null;
 
-    // Score data (placeholder — no score tracking in ClientGameState yet)
+    // Score data — use cumulative scores from roundResult if available
+    const roundResult = useGameStore.getState().roundResult;
     const scores = gameState.players.map((p, i) => ({
       name: p.name,
-      score: 0,
+      score: roundResult?.scores[i] ?? 0,
       isMe: i === gameState.myIndex,
     }));
 

--- a/apps/web/src/pages/GamePage.tsx
+++ b/apps/web/src/pages/GamePage.tsx
@@ -1,13 +1,15 @@
 import { useState } from "react";
-import { Link } from "react-router";
+import { Link, useNavigate } from "react-router";
 import TopBar from "../components/layout/TopBar.js";
 import GameTable from "../components/game/GameTable.js";
+import RoundResultModal from "../components/game/RoundResultModal.js";
 import TileTracker from "../components/sidebar/TileTracker.js";
 import ScoreBoard from "../components/sidebar/ScoreBoard.js";
 import RoundInfo from "../components/sidebar/RoundInfo.js";
 import ChatPanel from "../components/chat/ChatPanel.js";
 import { useGameData } from "../hooks/useGameData.js";
 import { useTileTracker } from "../hooks/useTileTracker.js";
+import { useGameStore } from "../stores/gameStore.js";
 
 export default function GamePage() {
   const {
@@ -23,6 +25,8 @@ export default function GamePage() {
     handleDiscardTile,
   } = useGameData();
 
+  const roundResult = useGameStore((s) => s.roundResult);
+  const navigate = useNavigate();
   const trackerSections = useTileTracker();
 
   const [chatMessages, setChatMessages] = useState<
@@ -109,6 +113,17 @@ export default function GamePage() {
           />
         </div>
       </div>
+
+      {roundResult && gameState && (
+        <RoundResultModal
+          result={roundResult}
+          players={gameState.players}
+          onClose={() => {
+            useGameStore.getState().clearRoundResult();
+            navigate("/");
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/pages/MobileGamePage.tsx
+++ b/apps/web/src/pages/MobileGamePage.tsx
@@ -1,13 +1,15 @@
 import { useState } from "react";
-import { Link } from "react-router";
+import { Link, useNavigate } from "react-router";
 import Tile from "../components/tile/Tile.js";
 import TileWall from "../components/tile/TileWall.js";
 import PlayerHand from "../components/game/PlayerHand.js";
 import GoldenTileIndicator from "../components/game/GoldenTileIndicator.js";
 import ActionBubbles from "../components/game/ActionBubbles.js";
+import RoundResultModal from "../components/game/RoundResultModal.js";
 import TileTracker from "../components/sidebar/TileTracker.js";
 import { useGameData } from "../hooks/useGameData.js";
 import { useTileTracker } from "../hooks/useTileTracker.js";
+import { useGameStore } from "../stores/gameStore.js";
 
 const WALL_STACKS = 10;
 
@@ -48,6 +50,8 @@ export default function MobileGamePage() {
     handleDiscardTile,
   } = useGameData();
 
+  const roundResult = useGameStore((s) => s.roundResult);
+  const navigate = useNavigate();
   const trackerSections = useTileTracker();
 
   const [showTracker, setShowTracker] = useState(false);
@@ -430,6 +434,17 @@ export default function MobileGamePage() {
         discardHint={discardHint}
         onPass={handlePass}
       />
+
+      {roundResult && gameState && (
+        <RoundResultModal
+          result={roundResult}
+          players={gameState.players}
+          onClose={() => {
+            useGameStore.getState().clearRoundResult();
+            navigate("/");
+          }}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Show game over overlay when round ends and wire live scores into ScoreBoard.

Ticket #17 already landed: roundResult in gameStore, gameOver handler in useSocket, payments/breakdown in server payload, nextRound stub.

This ticket needs:
1. RoundResultModal component — overlay showing winner/draw, scoring breakdown, payments, total scores, back-to-lobby button
2. Wire into GamePage and MobileGamePage — show modal when roundResult is set
3. Wire live scores into ScoreBoard — replace score:0 placeholder in useGameData with actual scores from roundResult or cumulative tracking
4. Handle draw case with 流局 display
5. Clear roundResult on close and navigate to lobby

Closes #37