### PR TITLE
Lobby to game-over integration flow test

### DIFF
--- a/apps/server/src/game/__tests__/flowTest.test.ts
+++ b/apps/server/src/game/__tests__/flowTest.test.ts
@@ -323,7 +323,7 @@ describe("Lobby → Game-Over integration flow", () => {
       await setupRoom(socket, "ActionPlayer");
 
       const stateUpdates: ClientGameState[] = [];
-      let discardedTileId: string | undefined;
+      let discardedTileId: number | undefined;
       let discardVerified = false;
 
       socket.on("gameStateUpdate" as any, (state: ClientGameState) => {
@@ -332,7 +332,7 @@ describe("Lobby → Game-Over integration flow", () => {
         // After we discard, check that the tile shows up in our discards
         if (discardedTileId && !discardVerified) {
           const myDiscards = state.players[state.myIndex].discards;
-          if (myDiscards.some((t: { id: string }) => t.id === discardedTileId)) {
+          if (myDiscards.some((t) => t.id === discardedTileId)) {
             discardVerified = true;
           }
         }


### PR DESCRIPTION
Test the complete user flow from lobby to game-over: create room from LobbyPage, add bots, start game, play 2 rounds to verify next-round transition works. Fix any bugs found inline.

Specifically verify:
1. LobbyPage fetches rulesets and rooms correctly
2. Room creation via socket works, navigates to RoomPage
3. Adding bots updates room info live
4. Start game transitions to GamePage
5. Game state populates correctly (hand, discards, melds, wall, golden tile)
6. Action bubbles appear on actionRequired
7. Discard flow works (select tile, click again to discard)
8. Game over modal appears with correct scoring
9. Back to lobby button works
10. Second game can be started from lobby

Closes #41