### PR TITLE
Manual integration playtest - full Fuzhou game

### DIFF
--- a/apps/server/src/game/__tests__/playtest.test.ts
+++ b/apps/server/src/game/__tests__/playtest.test.ts
@@ -131,7 +131,7 @@ describe("Full Fuzhou playtest", () => {
     it("GET /api/rulesets returns fuzhou", async () => {
       const res = await fetch(`${baseUrl}/api/rulesets`);
       expect(res.status).toBe(200);
-      const data: { id: string; name: string; description: string }[] = await res.json();
+      const data = (await res.json()) as { id: string; name: string; description: string }[];
       expect(Array.isArray(data)).toBe(true);
       const fuzhou = data.find((r) => r.id === "fuzhou");
       expect(fuzhou).toBeDefined();
@@ -152,13 +152,13 @@ describe("Full Fuzhou playtest", () => {
         body: JSON.stringify({ ruleSetId: "fuzhou" }),
       });
       expect(createRes.status).toBe(201);
-      const room: RoomInfo = await createRes.json();
+      const room = (await createRes.json()) as RoomInfo;
       expect(room.id).toBeTruthy();
       expect(room.ruleSetId).toBe("fuzhou");
 
       const getRes = await fetch(`${baseUrl}/api/rooms/${room.id}`);
       expect(getRes.status).toBe(200);
-      const fetched: RoomInfo = await getRes.json();
+      const fetched = (await getRes.json()) as RoomInfo;
       expect(fetched.id).toBe(room.id);
     });
   });


### PR DESCRIPTION
Boot the app and play a full Fuzhou mahjong game end-to-end. Document all bugs found.

Steps:
1. Start server + web locally (or use deployed URL)
2. Navigate to lobby, verify /api/rulesets and /api/rooms endpoints work
3. Create room with Fuzhou ruleset
4. Add 3 bots from room page
5. Start game, verify transition to game table
6. Play through: deal, flower replacement, golden tile indicator, discard, chi/peng/gang/hu
7. Verify action bubbles appear when server sends availableActions
8. Verify tile tracker updates as tiles are played
9. Complete game (win or draw)
10. Check mobile layout
11. File bugs as new tickets for anything broken

This is automated where possible — write a test script that connects via socket, creates room, adds bots, starts game, and plays through with auto-responses. Log all events and flag any errors or unexpected states.

Closes #26