### PR TITLE
Round result next-round button and round tracking

### DIFF
--- a/apps/web/src/components/game/RoundResultModal.tsx
+++ b/apps/web/src/components/game/RoundResultModal.tsx
@@ -7,12 +7,14 @@ interface Player {
 interface RoundResultModalProps {
   result: RoundResult;
   players: Player[];
+  onNextRound: () => void;
   onClose: () => void;
 }
 
 export default function RoundResultModal({
   result,
   players,
+  onNextRound,
   onClose,
 }: RoundResultModalProps) {
   const isWin = result.winnerId !== null;
@@ -119,13 +121,21 @@ export default function RoundResultModal({
           </div>
         </div>
 
-        {/* Back to lobby button */}
-        <button
-          onClick={onClose}
-          className="w-full py-2.5 min-h-[44px] rounded-lg bg-amber-600 hover:bg-amber-500 text-white font-medium transition-colors cursor-pointer"
-        >
-          返回大厅
-        </button>
+        {/* Action buttons */}
+        <div className="flex gap-3">
+          <button
+            onClick={onNextRound}
+            className="flex-1 py-2.5 min-h-[44px] rounded-lg bg-green-700 hover:bg-green-600 text-white font-medium transition-colors cursor-pointer"
+          >
+            下一局
+          </button>
+          <button
+            onClick={onClose}
+            className="flex-1 py-2.5 min-h-[44px] rounded-lg bg-neutral-700 hover:bg-neutral-600 text-white font-medium transition-colors cursor-pointer"
+          >
+            返回大厅
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/hooks/useGameData.ts
+++ b/apps/web/src/hooks/useGameData.ts
@@ -112,9 +112,12 @@ export function useGameData() {
     const north = mapPlayer(2);
     const east = mapPlayer(3);
 
-    // Round label
-    const dealerWind = WIND_LABELS[gameState.players[gameState.dealerIndex].seatWind] ?? "东";
-    const roundLabel = `${dealerWind}风 · 第一局`;
+    // Round label — use gameState fields if available (ticket #25), fallback otherwise
+    const gs = gameState as typeof gameState & { prevalentWind?: string; roundInWind?: number };
+    const prevalentWind = WIND_LABELS[gs.prevalentWind ?? "east"] ?? "东";
+    const roundNumMap = ["一", "二", "三", "四"];
+    const roundNum = roundNumMap[(gs.roundInWind ?? 1) - 1] ?? String(gs.roundInWind ?? 1);
+    const roundLabel = `${prevalentWind}风 · 第${roundNum}局`;
 
     // Current turn as relative index (0=south, 1=west, 2=north, 3=east)
     const currentTurn = (gameState.currentTurn - gameState.myIndex + 4) % 4;

--- a/apps/web/src/pages/GamePage.tsx
+++ b/apps/web/src/pages/GamePage.tsx
@@ -118,6 +118,11 @@ export default function GamePage() {
         <RoundResultModal
           result={roundResult}
           players={gameState.players}
+          onNextRound={() => {
+            useGameStore.getState().clearRoundResult();
+            const socket = useGameStore.getState().socket;
+            if (socket) socket.emit("nextRound");
+          }}
           onClose={() => {
             useGameStore.getState().clearRoundResult();
             navigate("/");

--- a/apps/web/src/pages/MobileGamePage.tsx
+++ b/apps/web/src/pages/MobileGamePage.tsx
@@ -441,6 +441,11 @@ export default function MobileGamePage() {
         <RoundResultModal
           result={roundResult}
           players={gameState.players}
+          onNextRound={() => {
+            useGameStore.getState().clearRoundResult();
+            const socket = useGameStore.getState().socket;
+            if (socket) socket.emit("nextRound");
+          }}
           onClose={() => {
             useGameStore.getState().clearRoundResult();
             navigate("/");


### PR DESCRIPTION
Add Next Round button to RoundResultModal that emits nextRound socket event. Show round-specific payments AND cumulative totals separately. Update round counter to read from game state instead of hardcoded first round. Show current wind and dealer indicator.

Closes #46