### PR TITLE
Player disconnect and reconnect handling

### DIFF
--- a/apps/server/src/game/Room.ts
+++ b/apps/server/src/game/Room.ts
@@ -84,6 +84,7 @@ export class Room {
         name: p.name,
         isBot: p.isBot,
         ready: p.ready,
+        connected: p.isBot || !!p.socketId,
       })),
       ruleSetId: this.ruleSetId,
       started: this.state !== "waiting",

--- a/apps/server/src/socketHandlers.ts
+++ b/apps/server/src/socketHandlers.ts
@@ -157,6 +157,47 @@ export function registerSocketHandlers(
       }
     });
 
+    socket.on("reconnect", ({ roomId, playerName }) => {
+      try {
+        const room = roomManager.getRoom(roomId);
+        if (!room) {
+          socket.emit("error", "Room not found");
+          return;
+        }
+
+        const playerIdx = room.players.findIndex(
+          (p) => p.name === playerName && !p.isBot
+        );
+        if (playerIdx === -1) {
+          socket.emit("error", "Player not found");
+          return;
+        }
+
+        // Restore socket mapping
+        room.players[playerIdx].socketId = socket.id;
+        socket.join(roomId);
+        socketToRoom.set(socket.id, { roomId, playerIndex: playerIdx });
+
+        // Send current game state
+        if (room.engine) {
+          socket.emit(
+            "gameStateUpdate",
+            room.engine.toClientGameState(playerIdx)
+          );
+        }
+        socket.emit("roomUpdate", room.toRoomInfo());
+        // Notify other players that this player reconnected
+        socket.to(roomId).emit("roomUpdate", room.toRoomInfo());
+
+        console.log(
+          `Player "${playerName}" reconnected to room ${roomId} (seat ${playerIdx})`
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        socket.emit("error", message);
+      }
+    });
+
     socket.on("disconnect", () => {
       console.log(`Client disconnected: ${socket.id}`);
       const mapping = socketToRoom.get(socket.id);

--- a/apps/web/src/hooks/useSocket.ts
+++ b/apps/web/src/hooks/useSocket.ts
@@ -25,6 +25,15 @@ export function useSocket() {
 
     socket.on("connect", () => {
       useGameStore.getState().setConnected(true);
+
+      // Auto-reconnect to room if session info exists
+      try {
+        const roomId = sessionStorage.getItem("majiang_roomId");
+        const playerName = sessionStorage.getItem("majiang_playerName");
+        if (roomId && playerName) {
+          socket.emit("reconnect", { roomId, playerName });
+        }
+      } catch { /* sessionStorage unavailable */ }
     });
 
     socket.on("disconnect", () => {

--- a/apps/web/src/stores/gameStore.ts
+++ b/apps/web/src/stores/gameStore.ts
@@ -100,6 +100,10 @@ export const useGameStore = create<GameStore>((set, get) => ({
     set({ playerName });
     socket.emit("createRoom", { playerName, ruleSetId }, (room) => {
       set({ roomInfo: room, roomId: room.id });
+      try {
+        sessionStorage.setItem("majiang_roomId", room.id);
+        sessionStorage.setItem("majiang_playerName", playerName);
+      } catch { /* sessionStorage unavailable */ }
     });
   },
 
@@ -110,6 +114,10 @@ export const useGameStore = create<GameStore>((set, get) => ({
     socket.emit("joinRoom", { roomId, playerName }, (room) => {
       if (room) {
         set({ roomInfo: room, roomId: room.id });
+        try {
+          sessionStorage.setItem("majiang_roomId", room.id);
+          sessionStorage.setItem("majiang_playerName", playerName);
+        } catch { /* sessionStorage unavailable */ }
       } else {
         set({ errorMessage: "Failed to join room" });
       }
@@ -135,5 +143,11 @@ export const useGameStore = create<GameStore>((set, get) => ({
     set({ availableActions: null });
   },
 
-  reset: () => set({ ...initialState }),
+  reset: () => {
+    try {
+      sessionStorage.removeItem("majiang_roomId");
+      sessionStorage.removeItem("majiang_playerName");
+    } catch { /* sessionStorage unavailable */ }
+    set({ ...initialState });
+  },
 }));

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -54,11 +54,12 @@ export interface ClientEvents {
   startGame: () => void;
   playerAction: (action: import("./action.js").GameAction) => void;
   nextRound: () => void;
+  reconnect: (data: { roomId: string; playerName: string }) => void;
 }
 
 export interface RoomInfo {
   id: string;
-  players: { name: string; isBot: boolean; ready: boolean }[];
+  players: { name: string; isBot: boolean; ready: boolean; connected: boolean }[];
   ruleSetId: string;
   started: boolean;
 }


### PR DESCRIPTION
Implement proper disconnect/reconnect so players can rejoin their seat with full game state restored.

Current state: socketHandlers.ts clears socketId on disconnect but has no reconnect flow.

Needed:
1. Server: on reconnect, match player by name or token to existing seat, restore socketId, send current gameState
2. Client: useSocket should attempt reconnection with room/player info from store
3. Handle mid-game disconnect: bot takes over until player reconnects
4. Handle lobby disconnect: clean removal from room
5. Store roomId/playerName in sessionStorage so page refresh can rejoin

Closes #52