### PR TITLE
Improve bot AI - chi support and smarter discards

### DIFF
--- a/apps/server/src/game/BotPlayer.ts
+++ b/apps/server/src/game/BotPlayer.ts
@@ -1,5 +1,40 @@
-import { ActionType } from "@majiang/shared";
+import { ActionType, tileKey } from "@majiang/shared";
 import type { GameAction, AvailableActions, TileInstance } from "@majiang/shared";
+
+/**
+ * Score a tile based on how useful it is in the hand.
+ * Higher score = more valuable = keep it.
+ */
+export function scoreTile(tile: TileInstance, hand: TileInstance[]): number {
+  let score = 0;
+  const key = tileKey(tile.tile);
+
+  // Pairs are valuable
+  const matching = hand.filter((t) => tileKey(t.tile) === key).length;
+  score += matching * 10;
+
+  // Adjacent suited tiles are valuable (potential sequences)
+  if (tile.tile.kind === "suited") {
+    const suit = tile.tile.suit;
+    const val = tile.tile.value;
+    const hasAdj1 = hand.some(
+      (t) =>
+        t.tile.kind === "suited" &&
+        t.tile.suit === suit &&
+        Math.abs(t.tile.value - val) === 1
+    );
+    const hasAdj2 = hand.some(
+      (t) =>
+        t.tile.kind === "suited" &&
+        t.tile.suit === suit &&
+        Math.abs(t.tile.value - val) === 2
+    );
+    if (hasAdj1) score += 5;
+    if (hasAdj2) score += 2;
+  }
+
+  return score;
+}
 
 export class BotPlayer {
   static choosePostDrawAction(
@@ -7,7 +42,7 @@ export class BotPlayer {
     hand: TileInstance[],
     playerIndex: number
   ): GameAction {
-    // Priority: Hu > AnGang > Discard
+    // Priority: Hu > AnGang > BuGang > Discard
     if (actions.canHu) {
       return { type: ActionType.Hu, playerIndex };
     }
@@ -28,13 +63,14 @@ export class BotPlayer {
       };
     }
 
-    // Discard a random tile
+    // Discard the tile with the lowest score
     if (actions.canDiscard && hand.length > 0) {
-      const randomIndex = Math.floor(Math.random() * hand.length);
+      const scored = hand.map((t) => ({ tile: t, score: scoreTile(t, hand) }));
+      scored.sort((a, b) => a.score - b.score);
       return {
         type: ActionType.Discard,
         playerIndex,
-        tile: hand[randomIndex],
+        tile: scored[0].tile,
       };
     }
 
@@ -50,17 +86,35 @@ export class BotPlayer {
     actions: AvailableActions,
     playerIndex: number
   ): GameAction {
-    // Priority: Hu > Peng > Pass (no chi for basic bot)
+    // Priority: Hu > Peng > MingGang > Chi > Pass
     if (actions.canHu) {
       return { type: ActionType.Hu, playerIndex };
     }
 
     if (actions.canPeng) {
-      return { type: ActionType.Peng, playerIndex, targetTile: undefined as never };
+      return {
+        type: ActionType.Peng,
+        playerIndex,
+        targetTile: undefined as never,
+      };
     }
 
     if (actions.canMingGang) {
-      return { type: ActionType.MingGang, playerIndex, targetTile: undefined as never };
+      return {
+        type: ActionType.MingGang,
+        playerIndex,
+        targetTile: undefined as never,
+      };
+    }
+
+    if (actions.chiOptions.length > 0) {
+      const pair = actions.chiOptions[0] as [TileInstance, TileInstance];
+      return {
+        type: ActionType.Chi,
+        playerIndex,
+        tiles: pair,
+        targetTile: undefined as never,
+      };
     }
 
     return { type: ActionType.Pass, playerIndex };

--- a/apps/server/src/game/__tests__/BotPlayer.test.ts
+++ b/apps/server/src/game/__tests__/BotPlayer.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { ActionType, Suit } from "@majiang/shared";
 import type { AvailableActions, TileInstance } from "@majiang/shared";
-import { BotPlayer } from "../BotPlayer.js";
+import { BotPlayer, scoreTile } from "../BotPlayer.js";
 
-function makeTile(id: number, value: number): TileInstance {
-  return { id, tile: { kind: "suited", suit: Suit.Wan, value: value as 1 } };
+function makeTile(id: number, value: number, suit: Suit = Suit.Wan): TileInstance {
+  return { id, tile: { kind: "suited", suit, value: value as 1 } };
+}
+
+function makeWindTile(id: number, windType: "east" | "south" | "west" | "north"): TileInstance {
+  return { id, tile: { kind: "wind", windType } };
 }
 
 const noActions: AvailableActions = {
@@ -45,6 +49,22 @@ describe("BotPlayer", () => {
       expect(result.type).toBe(ActionType.Discard);
       expect(hand.map((t) => t.id)).toContain((result as { tile: TileInstance }).tile.id);
     });
+
+    it("should discard isolated tiles before connected ones", () => {
+      // Hand: 1w, 2w, 3w, 9w (isolated) — should discard 9w
+      const hand = [makeTile(0, 1), makeTile(1, 2), makeTile(2, 3), makeTile(3, 9)];
+      const result = BotPlayer.choosePostDrawAction(noActions, hand, 0);
+      expect(result.type).toBe(ActionType.Discard);
+      expect((result as { tile: TileInstance }).tile.id).toBe(3);
+    });
+
+    it("should keep pairs over isolated tiles", () => {
+      // Hand: 5w, 5w, 9w — should discard 9w (pair is more valuable)
+      const hand = [makeTile(0, 5), makeTile(1, 5), makeTile(2, 9)];
+      const result = BotPlayer.choosePostDrawAction(noActions, hand, 0);
+      expect(result.type).toBe(ActionType.Discard);
+      expect((result as { tile: TileInstance }).tile.id).toBe(2);
+    });
   });
 
   describe("chooseResponseAction", () => {
@@ -60,10 +80,66 @@ describe("BotPlayer", () => {
       expect(result.type).toBe(ActionType.Peng);
     });
 
+    it("should ming gang when possible and not hu or peng", () => {
+      const actions: AvailableActions = { ...noActions, canMingGang: true, canPass: true };
+      const result = BotPlayer.chooseResponseAction(actions, 1);
+      expect(result.type).toBe(ActionType.MingGang);
+    });
+
+    it("should chi when chi options available and no higher priority action", () => {
+      const chiPair: [TileInstance, TileInstance] = [makeTile(0, 2), makeTile(1, 3)];
+      const actions: AvailableActions = {
+        ...noActions,
+        chiOptions: [chiPair],
+        canPass: true,
+      };
+      const result = BotPlayer.chooseResponseAction(actions, 1);
+      expect(result.type).toBe(ActionType.Chi);
+      if (result.type === ActionType.Chi) {
+        expect(result.tiles).toEqual(chiPair);
+      }
+    });
+
+    it("should prefer peng over chi", () => {
+      const chiPair: [TileInstance, TileInstance] = [makeTile(0, 2), makeTile(1, 3)];
+      const actions: AvailableActions = {
+        ...noActions,
+        canPeng: true,
+        chiOptions: [chiPair],
+        canPass: true,
+      };
+      const result = BotPlayer.chooseResponseAction(actions, 1);
+      expect(result.type).toBe(ActionType.Peng);
+    });
+
     it("should pass when nothing special available", () => {
       const actions: AvailableActions = { ...noActions, canPass: true, canDiscard: false };
       const result = BotPlayer.chooseResponseAction(actions, 1);
       expect(result.type).toBe(ActionType.Pass);
+    });
+  });
+
+  describe("scoreTile", () => {
+    it("scores pairs higher than isolated tiles", () => {
+      const hand = [makeTile(0, 5), makeTile(1, 5), makeTile(2, 9)];
+      const pairScore = scoreTile(hand[0], hand);
+      const isolatedScore = scoreTile(hand[2], hand);
+      expect(pairScore).toBeGreaterThan(isolatedScore);
+    });
+
+    it("scores adjacent suited tiles higher than isolated ones", () => {
+      const hand = [makeTile(0, 3), makeTile(1, 4), makeTile(2, 9)];
+      const adjacentScore = scoreTile(hand[0], hand);
+      const isolatedScore = scoreTile(hand[2], hand);
+      expect(adjacentScore).toBeGreaterThan(isolatedScore);
+    });
+
+    it("scores wind tiles without adjacency bonus", () => {
+      const windTile = makeWindTile(0, "east");
+      const hand = [windTile, makeTile(1, 3), makeTile(2, 4)];
+      const score = scoreTile(windTile, hand);
+      // Wind tile alone: matching count = 1 -> 10, no adjacency
+      expect(score).toBe(10);
     });
   });
 


### PR DESCRIPTION
Improve BotPlayer to play more realistically:
1. Add chi support (currently always passes on sequences)
2. Smarter discard - keep pairs/connected tiles, discard isolated ones
3. Fix ming gang priority in chooseResponseAction

Target: reasonable amateur bot, not perfect play.

Closes #59