### PR TITLE
Extend tile animations to all players

### DIFF
--- a/apps/web/src/components/game/GameTable.tsx
+++ b/apps/web/src/components/game/GameTable.tsx
@@ -1,4 +1,5 @@
 import type { Tile as TileType } from "@majiang/shared";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import Tile from "../tile/Tile.js";
 import TileWall from "../tile/TileWall.js";
 import OpponentArea from "./OpponentArea.js";
@@ -45,6 +46,9 @@ export default function GameTable({
   onPass, onSelectTile, onDiscardTile, onFlowerClick, centerContent,
   goldenTile, flippedTile,
 }: GameTableProps) {
+  const prefersReduced = useReducedMotion();
+  const dur = prefersReduced ? 0 : 0.15;
+
   const [south, west, north, east] = players;
   const perWall = Math.ceil(wallRemaining / 4);
   const w1 = Math.min(perWall, wallRemaining);
@@ -87,7 +91,13 @@ export default function GameTable({
           {/* (0,1) north: discards + wall */}
           <div className="flex flex-col items-center justify-end gap-2 overflow-hidden">
             <div className="flex flex-wrap-reverse gap-0.5 justify-center content-start overflow-hidden w-full">
-              {north.discards.map((c, i) => <Tile key={i} char={c} variant="face" size="md" />)}
+              <AnimatePresence>
+                {north.discards.map((c, i) => (
+                  <motion.div key={`${c}-${i}`} initial={{ opacity: 0, scale: 0.7 }} animate={{ opacity: 1, scale: 1 }} transition={{ duration: dur }}>
+                    <Tile char={c} variant="face" size="md" />
+                  </motion.div>
+                ))}
+              </AnimatePresence>
             </div>
             <TileWall direction="horizontal" remaining={w3} totalStacks={WALL_STACKS} consumeFrom="end" faceCenter="bottom" />
           </div>
@@ -97,7 +107,13 @@ export default function GameTable({
           {/* (1,0) west: discards + wall */}
           <div className="flex items-center justify-end gap-2 overflow-hidden">
             <div className="flex flex-col flex-wrap-reverse gap-0.5 items-end overflow-hidden h-full">
-              {west.discards.map((c, i) => <Tile key={i} char={c} variant="face" size="md" rotate={-90} />)}
+              <AnimatePresence>
+                {west.discards.map((c, i) => (
+                  <motion.div key={`${c}-${i}`} initial={{ opacity: 0, scale: 0.7 }} animate={{ opacity: 1, scale: 1 }} transition={{ duration: dur }}>
+                    <Tile char={c} variant="face" size="md" rotate={-90} />
+                  </motion.div>
+                ))}
+              </AnimatePresence>
             </div>
             <TileWall direction="vertical" remaining={w4} totalStacks={WALL_STACKS} consumeFrom="end" faceCenter="right" />
           </div>
@@ -116,7 +132,13 @@ export default function GameTable({
           <div className="flex items-center justify-start gap-2 overflow-hidden">
             <TileWall direction="vertical" remaining={w2} totalStacks={WALL_STACKS} consumeFrom="start" faceCenter="left" />
             <div className="flex flex-col flex-wrap gap-0.5 items-start overflow-hidden h-full">
-              {east.discards.map((c, i) => <Tile key={i} char={c} variant="face" size="md" rotate={90} />)}
+              <AnimatePresence>
+                {east.discards.map((c, i) => (
+                  <motion.div key={`${c}-${i}`} initial={{ opacity: 0, scale: 0.7 }} animate={{ opacity: 1, scale: 1 }} transition={{ duration: dur }}>
+                    <Tile char={c} variant="face" size="md" rotate={90} />
+                  </motion.div>
+                ))}
+              </AnimatePresence>
             </div>
           </div>
 
@@ -126,7 +148,13 @@ export default function GameTable({
           <div className="flex flex-col items-center justify-start gap-2 overflow-hidden">
             <TileWall direction="horizontal" remaining={w1} totalStacks={WALL_STACKS} consumeFrom="start" faceCenter="top" />
             <div className="flex flex-wrap gap-0.5 justify-start content-start overflow-hidden w-full">
-              {south.discards.map((c, i) => <Tile key={i} char={c} variant="face" size="md" />)}
+              <AnimatePresence>
+                {south.discards.map((c, i) => (
+                  <motion.div key={`${c}-${i}`} initial={{ opacity: 0, scale: 0.7 }} animate={{ opacity: 1, scale: 1 }} transition={{ duration: dur }}>
+                    <Tile char={c} variant="face" size="md" />
+                  </motion.div>
+                ))}
+              </AnimatePresence>
             </div>
           </div>
           {/* (2,2) empty */}

--- a/apps/web/src/components/game/OpponentArea.tsx
+++ b/apps/web/src/components/game/OpponentArea.tsx
@@ -1,3 +1,4 @@
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import Tile from "../tile/Tile.js";
 
 interface OpponentAreaProps {
@@ -24,24 +25,40 @@ export default function OpponentArea(props: OpponentAreaProps) {
 function NorthPlayer({
   name, handCount, discards, melds, flowerCount, isCurrentTurn, onFlowerClick,
 }: OpponentAreaProps) {
+  const prefersReduced = useReducedMotion();
+  const dur = prefersReduced ? 0 : 0.15;
+  const meldDur = prefersReduced ? 0 : 0.2;
+
   return (
     <div className="flex items-end justify-center gap-3 h-full overflow-hidden">
       {/* Hand backs */}
-      <div className="shrink-0 flex gap-0.5 items-end pt-4 pb-1">
+      <motion.div
+        layout
+        transition={{ duration: dur }}
+        className="shrink-0 flex gap-0.5 items-end pt-4 pb-1"
+      >
         {Array.from({ length: handCount }, (_, i) => (
           <Tile key={i} variant="back" size="md" />
         ))}
-      </div>
+      </motion.div>
       {/* Melds (right side = opponent's left hand) */}
       {melds.length > 0 && (
         <div className="shrink-0 border border-white/[.12] rounded-sm px-1.5 pt-4 pb-1 flex gap-2 items-end">
-          {melds.map((meld, i) => (
-            <div key={i} className="flex gap-px">
-              {meld.map((c, j) => (
-                <Tile key={j} char={c} variant="face" size="md" />
-              ))}
-            </div>
-          ))}
+          <AnimatePresence>
+            {melds.map((meld, i) => (
+              <motion.div
+                key={`meld-${i}-${meld.join(",")}`}
+                initial={{ opacity: 0, scale: 0.8, x: -15 }}
+                animate={{ opacity: 1, scale: 1, x: 0 }}
+                transition={{ duration: meldDur }}
+                className="flex gap-px"
+              >
+                {meld.map((c, j) => (
+                  <Tile key={j} char={c} variant="face" size="md" />
+                ))}
+              </motion.div>
+            ))}
+          </AnimatePresence>
           <span className="text-[11px] text-white/30 font-medium">副露</span>
         </div>
       )}
@@ -65,6 +82,9 @@ function SidePlayer({
 }: OpponentAreaProps) {
   const rotate = position === "west" ? -90 as const : 90 as const;
   const isWest = position === "west";
+  const prefersReduced = useReducedMotion();
+  const dur = prefersReduced ? 0 : 0.15;
+  const meldDur = prefersReduced ? 0 : 0.2;
 
   const nameBlock = (
     <div className="shrink-0 flex items-center gap-1">
@@ -74,23 +94,35 @@ function SidePlayer({
   );
 
   const handBlock = (
-    <div className="shrink-0 flex flex-col gap-0.5 items-center">
+    <motion.div
+      layout
+      transition={{ duration: dur }}
+      className="shrink-0 flex flex-col gap-0.5 items-center"
+    >
       {Array.from({ length: handCount }, (_, i) => (
         <Tile key={i} variant="back" size="md" rotate={rotate} />
       ))}
-    </div>
+    </motion.div>
   );
 
   const meldsBlock = melds.length > 0 ? (
     <div className="shrink-0 border border-white/[.12] rounded-sm p-1.5 flex flex-col gap-1 items-center">
       {isWest && <span className="text-[11px] text-white/30 font-medium">副露</span>}
-      {melds.map((meld, i) => (
-        <div key={i} className="flex flex-col gap-px">
-          {meld.map((c, j) => (
-            <Tile key={j} char={c} variant="face" size="md" rotate={rotate} />
-          ))}
-        </div>
-      ))}
+      <AnimatePresence>
+        {melds.map((meld, i) => (
+          <motion.div
+            key={`meld-${i}-${meld.join(",")}`}
+            initial={{ opacity: 0, scale: 0.8, y: -15 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            transition={{ duration: meldDur }}
+            className="flex flex-col gap-px"
+          >
+            {meld.map((c, j) => (
+              <Tile key={j} char={c} variant="face" size="md" rotate={rotate} />
+            ))}
+          </motion.div>
+        ))}
+      </AnimatePresence>
       {!isWest && <span className="text-[11px] text-white/30 font-medium">副露</span>}
     </div>
   ) : null;

--- a/apps/web/src/pages/MobileGamePage.tsx
+++ b/apps/web/src/pages/MobileGamePage.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import Tile from "../components/tile/Tile.js";
 import TileWall from "../components/tile/TileWall.js";
 import PlayerHand from "../components/game/PlayerHand.js";
@@ -53,6 +54,10 @@ export default function MobileGamePage() {
   const roundResult = useGameStore((s) => s.roundResult);
   const navigate = useNavigate();
   const trackerSections = useTileTracker();
+
+  const prefersReduced = useReducedMotion();
+  const dur = prefersReduced ? 0 : 0.15;
+  const meldDur = prefersReduced ? 0 : 0.2;
 
   const [showTracker, setShowTracker] = useState(false);
   const [showChat, setShowChat] = useState(false);
@@ -112,48 +117,58 @@ export default function MobileGamePage() {
               </sup>
             </span>
           )}
-          <div className="flex flex-col gap-px items-center flex-1 min-h-0 overflow-hidden">
+          <motion.div layout transition={{ duration: dur }} className="flex flex-col gap-px items-center flex-1 min-h-0 overflow-hidden">
             {Array.from({ length: Math.min(west.handCount, 13) }, (_, i) => (
               <Tile key={i} variant="back" size="sm" rotate={-90} />
             ))}
-          </div>
-          {west.melds.map((meld, i) => (
-            <div
-              key={i}
-              className="flex flex-col gap-px border border-white/[.12] rounded-sm p-0.5 shrink-0"
-            >
-              {meld.map((c, j) => (
-                <Tile
-                  key={j}
-                  char={c}
-                  variant="face"
-                  size="sm"
-                  rotate={-90}
-                />
-              ))}
-            </div>
-          ))}
+          </motion.div>
+          <AnimatePresence>
+            {west.melds.map((meld, i) => (
+              <motion.div
+                key={`meld-${i}-${meld.join(",")}`}
+                initial={{ opacity: 0, scale: 0.8, y: -15 }}
+                animate={{ opacity: 1, scale: 1, y: 0 }}
+                transition={{ duration: meldDur }}
+                className="flex flex-col gap-px border border-white/[.12] rounded-sm p-0.5 shrink-0"
+              >
+                {meld.map((c, j) => (
+                  <Tile
+                    key={j}
+                    char={c}
+                    variant="face"
+                    size="sm"
+                    rotate={-90}
+                  />
+                ))}
+              </motion.div>
+            ))}
+          </AnimatePresence>
         </div>
 
         {/* Center column: North + Center table */}
         <div className="flex-1 min-w-0 flex flex-col gap-1">
           {/* North player hand area */}
           <div className="shrink-0 bg-black/10 rounded px-2 py-1 flex items-end justify-center gap-2 overflow-hidden">
-            <div className="flex gap-px items-end min-w-0 overflow-hidden flex-shrink">
+            <motion.div layout transition={{ duration: dur }} className="flex gap-px items-end min-w-0 overflow-hidden flex-shrink">
               {Array.from({ length: Math.min(north.handCount, 13) }, (_, i) => (
                 <Tile key={i} variant="back" size="sm" />
               ))}
-            </div>
-            {north.melds.map((meld, i) => (
-              <div
-                key={i}
-                className="flex gap-px border border-white/[.12] rounded-sm px-0.5 py-0.5 shrink-0"
-              >
-                {meld.map((c, j) => (
-                  <Tile key={j} char={c} variant="face" size="sm" />
-                ))}
-              </div>
-            ))}
+            </motion.div>
+            <AnimatePresence>
+              {north.melds.map((meld, i) => (
+                <motion.div
+                  key={`meld-${i}-${meld.join(",")}`}
+                  initial={{ opacity: 0, scale: 0.8, x: -15 }}
+                  animate={{ opacity: 1, scale: 1, x: 0 }}
+                  transition={{ duration: meldDur }}
+                  className="flex gap-px border border-white/[.12] rounded-sm px-0.5 py-0.5 shrink-0"
+                >
+                  {meld.map((c, j) => (
+                    <Tile key={j} char={c} variant="face" size="sm" />
+                  ))}
+                </motion.div>
+              ))}
+            </AnimatePresence>
             <OpponentBadge
               name={north.name}
               hand={north.handCount}
@@ -167,24 +182,36 @@ export default function MobileGamePage() {
             <div />
             {/* (0,1) North discards */}
             <div className="flex flex-wrap-reverse gap-px justify-center content-start self-end overflow-hidden">
-              {north.discards.map((c, i) => (
-                <Tile key={i} char={c} variant="face" size="sm" />
-              ))}
+              <AnimatePresence>
+                {north.discards.map((c, i) => (
+                  <motion.div
+                    key={`${c}-${i}`}
+                    initial={{ opacity: 0, scale: 0.7 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    transition={{ duration: dur }}
+                  >
+                    <Tile char={c} variant="face" size="sm" />
+                  </motion.div>
+                ))}
+              </AnimatePresence>
             </div>
             <div />
 
             {/* (1,0) West discards + wall */}
             <div className="flex items-center justify-end gap-1 overflow-hidden">
               <div className="flex flex-col flex-wrap-reverse gap-px items-end justify-center h-full overflow-hidden">
-                {west.discards.map((c, i) => (
-                  <Tile
-                    key={i}
-                    char={c}
-                    variant="face"
-                    size="sm"
-                    rotate={-90}
-                  />
-                ))}
+                <AnimatePresence>
+                  {west.discards.map((c, i) => (
+                    <motion.div
+                      key={`${c}-${i}`}
+                      initial={{ opacity: 0, scale: 0.7 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      transition={{ duration: dur }}
+                    >
+                      <Tile char={c} variant="face" size="sm" rotate={-90} />
+                    </motion.div>
+                  ))}
+                </AnimatePresence>
               </div>
               <TileWall
                 direction="vertical"
@@ -240,24 +267,36 @@ export default function MobileGamePage() {
                 faceCenter="left"
               />
               <div className="flex flex-col flex-wrap gap-px items-start justify-center h-full overflow-hidden">
-                {east.discards.map((c, i) => (
-                  <Tile
-                    key={i}
-                    char={c}
-                    variant="face"
-                    size="sm"
-                    rotate={90}
-                  />
-                ))}
+                <AnimatePresence>
+                  {east.discards.map((c, i) => (
+                    <motion.div
+                      key={`${c}-${i}`}
+                      initial={{ opacity: 0, scale: 0.7 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      transition={{ duration: dur }}
+                    >
+                      <Tile char={c} variant="face" size="sm" rotate={90} />
+                    </motion.div>
+                  ))}
+                </AnimatePresence>
               </div>
             </div>
 
             <div />
             {/* (2,1) South discards */}
             <div className="flex flex-wrap gap-px justify-center content-start self-start overflow-hidden">
-              {south.discards.map((c, i) => (
-                <Tile key={i} char={c} variant="face" size="sm" />
-              ))}
+              <AnimatePresence>
+                {south.discards.map((c, i) => (
+                  <motion.div
+                    key={`${c}-${i}`}
+                    initial={{ opacity: 0, scale: 0.7 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    transition={{ duration: dur }}
+                  >
+                    <Tile char={c} variant="face" size="sm" />
+                  </motion.div>
+                ))}
+              </AnimatePresence>
             </div>
             <div />
           </div>
@@ -286,27 +325,32 @@ export default function MobileGamePage() {
               </sup>
             </span>
           )}
-          <div className="flex flex-col gap-px items-center flex-1 min-h-0 overflow-hidden">
+          <motion.div layout transition={{ duration: dur }} className="flex flex-col gap-px items-center flex-1 min-h-0 overflow-hidden">
             {Array.from({ length: Math.min(east.handCount, 13) }, (_, i) => (
               <Tile key={i} variant="back" size="sm" rotate={90} />
             ))}
-          </div>
-          {east.melds.map((meld, i) => (
-            <div
-              key={i}
-              className="flex flex-col gap-px border border-white/[.12] rounded-sm p-0.5 shrink-0"
-            >
-              {meld.map((c, j) => (
-                <Tile
-                  key={j}
-                  char={c}
-                  variant="face"
-                  size="sm"
-                  rotate={90}
-                />
-              ))}
-            </div>
-          ))}
+          </motion.div>
+          <AnimatePresence>
+            {east.melds.map((meld, i) => (
+              <motion.div
+                key={`meld-${i}-${meld.join(",")}`}
+                initial={{ opacity: 0, scale: 0.8, y: -15 }}
+                animate={{ opacity: 1, scale: 1, y: 0 }}
+                transition={{ duration: meldDur }}
+                className="flex flex-col gap-px border border-white/[.12] rounded-sm p-0.5 shrink-0"
+              >
+                {meld.map((c, j) => (
+                  <Tile
+                    key={j}
+                    char={c}
+                    variant="face"
+                    size="sm"
+                    rotate={90}
+                  />
+                ))}
+              </motion.div>
+            ))}
+          </AnimatePresence>
         </div>
       </div>
 


### PR DESCRIPTION
Add framer-motion draw/discard/meld animations for East/West/North players. Currently only SouthPlayer and PlayerHand have animations. Opponents show tiles appearing/disappearing instantly.

Scope:
- Discard animation: tile slides from player hand area to discard pile
- Draw animation: opponent hand count changes with subtle animation
- Meld animation: claimed tiles animate into meld area
- Keep lightweight: simple slide/fade since opponent tiles are face-down/smaller
- Apply to OpponentArea.tsx and relevant opponent rendering in GameTable/MobileGamePage

Closes #62