### PR TITLE
Wire chat messages through Socket-IO server

### DIFF
--- a/apps/server/src/socketHandlers.ts
+++ b/apps/server/src/socketHandlers.ts
@@ -203,6 +203,19 @@ export function registerSocketHandlers(
       }
     });
 
+    socket.on("chatMessage", ({ text }) => {
+      const mapping = socketToRoom.get(socket.id);
+      if (!mapping) return;
+      const room = roomManager.getRoom(mapping.roomId);
+      if (!room) return;
+      const player = room.players[mapping.playerIndex];
+      io.to(room.id).emit("chatMessage", {
+        sender: player.name,
+        text,
+        timestamp: Date.now(),
+      });
+    });
+
     socket.on("disconnect", () => {
       console.log(`Client disconnected: ${socket.id}`);
       const mapping = socketToRoom.get(socket.id);

--- a/apps/web/src/hooks/useSocket.ts
+++ b/apps/web/src/hooks/useSocket.ts
@@ -66,6 +66,10 @@ export function useSocket() {
       useGameStore.getState().setErrorMessage(msg);
     });
 
+    socket.on("chatMessage", ({ sender, text }) => {
+      useGameStore.getState().addChatMessage({ sender, text });
+    });
+
     return () => {
       socket.disconnect();
       socketRef.current = null;

--- a/apps/web/src/pages/GamePage.tsx
+++ b/apps/web/src/pages/GamePage.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Link, useNavigate } from "react-router";
 import TopBar from "../components/layout/TopBar.js";
 import GameTable from "../components/game/GameTable.js";
@@ -26,12 +25,9 @@ export default function GamePage() {
   } = useGameData();
 
   const roundResult = useGameStore((s) => s.roundResult);
+  const chatMessages = useGameStore((s) => s.chatMessages);
   const navigate = useNavigate();
   const trackerSections = useTileTracker();
-
-  const [chatMessages, setChatMessages] = useState<
-    { id: string; sender: string; text: string; isMe?: boolean }[]
-  >([]);
 
   if (!gameState || !data) {
     return (
@@ -99,16 +95,12 @@ export default function GamePage() {
           <ChatPanel
             messages={chatMessages}
             onSend={(text) => {
-              setChatMessages((prev) => [
-                ...prev,
-                { id: String(Date.now()), sender: "我", text, isMe: true },
-              ]);
+              const socket = useGameStore.getState().socket;
+              if (socket) socket.emit("chatMessage", { text });
             }}
             onEmoji={(emoji) => {
-              setChatMessages((prev) => [
-                ...prev,
-                { id: String(Date.now()), sender: "我", text: emoji, isMe: true },
-              ]);
+              const socket = useGameStore.getState().socket;
+              if (socket) socket.emit("chatMessage", { text: emoji });
             }}
           />
         </div>

--- a/apps/web/src/stores/gameStore.ts
+++ b/apps/web/src/stores/gameStore.ts
@@ -36,6 +36,10 @@ interface GameStore {
   // Round result
   roundResult: RoundResult | null;
 
+  // Chat
+  chatMessages: { id: string; sender: string; text: string; isMe?: boolean }[];
+  addChatMessage: (msg: { sender: string; text: string }) => void;
+
   // UI state
   selectedTileId: number | null;
   /** Epoch ms when the current action window expires (server timeout) */
@@ -78,6 +82,7 @@ const initialState = {
   gameState: null,
   availableActions: null,
   roundResult: null,
+  chatMessages: [],
   selectedTileId: null,
   actionDeadline: null,
   socket: null,
@@ -86,6 +91,13 @@ const initialState = {
 export const useGameStore = create<GameStore>((set, get) => ({
   ...initialState,
 
+  addChatMessage: ({ sender, text }) =>
+    set((state) => ({
+      chatMessages: [
+        ...state.chatMessages,
+        { id: String(Date.now()), sender, text, isMe: sender === state.playerName },
+      ],
+    })),
   setConnected: (connected) => set({ connected }),
   setRoom: (roomId, myIndex) => set({ roomId, myIndex }),
   setGameState: (gameState) => set({ gameState }),

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -46,6 +46,7 @@ export interface ServerEvents {
   actionError: (error: { message: string; code: string }) => void;
   roomUpdate: (room: RoomInfo) => void;
   error: (msg: string) => void;
+  chatMessage: (data: { sender: string; text: string; timestamp: number }) => void;
 }
 
 export interface ClientEvents {
@@ -56,6 +57,7 @@ export interface ClientEvents {
   playerAction: (action: import("./action.js").GameAction) => void;
   nextRound: () => void;
   reconnect: (data: { roomId: string; playerName: string }) => void;
+  chatMessage: (data: { text: string }) => void;
 }
 
 export interface RoomInfo {


### PR DESCRIPTION
Chat UI exists but messages are local-only. Wire through server so all players in a room see them.

Scope:
1. Add chatMessage event to ClientEvents and ServerEvents in events.ts
2. Server handler: on chatMessage, broadcast to room
3. Client useSocket: listen for chatMessage, update store
4. Store: add chatMessages state, wire ChatPanel to read from it
5. ChatPanel onSend: emit chatMessage instead of local setState

Closes #74