### PR TITLE
Connection disconnect overlay and error toasts

### DIFF
--- a/apps/web/src/pages/GamePage.tsx
+++ b/apps/web/src/pages/GamePage.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { Link, useNavigate } from "react-router";
 import TopBar from "../components/layout/TopBar.js";
 import GameTable from "../components/game/GameTable.js";
@@ -26,7 +27,22 @@ export default function GamePage() {
 
   const roundResult = useGameStore((s) => s.roundResult);
   const chatMessages = useGameStore((s) => s.chatMessages);
+  const connected = useGameStore((s) => s.connected);
+  const errorMessage = useGameStore((s) => s.errorMessage);
   const navigate = useNavigate();
+
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (errorMessage) {
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+      toastTimer.current = setTimeout(() => {
+        useGameStore.getState().setErrorMessage(null);
+      }, 5000);
+    }
+    return () => {
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+    };
+  }, [errorMessage]);
   const trackerSections = useTileTracker();
 
   if (!gameState || !data) {
@@ -132,6 +148,24 @@ export default function GamePage() {
             navigate("/");
           }}
         />
+      )}
+
+      {!connected && (
+        <div className="fixed inset-0 z-[300] bg-black/50 flex items-center justify-center">
+          <span className="text-white text-lg font-medium">连接中断，重连中...</span>
+        </div>
+      )}
+
+      {errorMessage && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[400] bg-red-900/90 border border-red-500 text-red-200 px-4 py-2 rounded shadow-lg flex items-center gap-2">
+          <span>{errorMessage}</span>
+          <button
+            onClick={() => useGameStore.getState().setErrorMessage(null)}
+            className="text-red-300 hover:text-white ml-1"
+          >
+            ✕
+          </button>
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/pages/LobbyPage.tsx
+++ b/apps/web/src/pages/LobbyPage.tsx
@@ -39,7 +39,7 @@ export default function LobbyPage() {
         setRuleSets(data);
         if (data.length > 0) setRuleSetId(data[0].id);
       })
-      .catch(() => {});
+      .catch(() => setErrorMessage("加载失败"));
   }, []);
 
   // Fetch rooms
@@ -47,7 +47,7 @@ export default function LobbyPage() {
     fetch(`${API_BASE}/api/rooms`)
       .then((r) => r.json())
       .then((data: RoomListItem[]) => setRooms(data.filter((r) => !r.started)))
-      .catch(() => {});
+      .catch(() => setErrorMessage("加载失败"));
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/pages/MobileGamePage.tsx
+++ b/apps/web/src/pages/MobileGamePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Link, useNavigate } from "react-router";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import TopBar from "../components/layout/TopBar.js";
@@ -57,7 +57,22 @@ export default function MobileGamePage() {
 
   const roundResult = useGameStore((s) => s.roundResult);
   const chatMessages = useGameStore((s) => s.chatMessages);
+  const connected = useGameStore((s) => s.connected);
+  const errorMessage = useGameStore((s) => s.errorMessage);
   const navigate = useNavigate();
+
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (errorMessage) {
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+      toastTimer.current = setTimeout(() => {
+        useGameStore.getState().setErrorMessage(null);
+      }, 5000);
+    }
+    return () => {
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+    };
+  }, [errorMessage]);
   const trackerSections = useTileTracker();
   const actionRemaining = useActionTimer();
 
@@ -531,6 +546,24 @@ export default function MobileGamePage() {
             navigate("/");
           }}
         />
+      )}
+
+      {!connected && (
+        <div className="fixed inset-0 z-[300] bg-black/50 flex items-center justify-center">
+          <span className="text-white text-lg font-medium">连接中断，重连中...</span>
+        </div>
+      )}
+
+      {errorMessage && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[400] bg-red-900/90 border border-red-500 text-red-200 px-4 py-2 rounded shadow-lg flex items-center gap-2">
+          <span>{errorMessage}</span>
+          <button
+            onClick={() => useGameStore.getState().setErrorMessage(null)}
+            className="text-red-300 hover:text-white ml-1"
+          >
+            ✕
+          </button>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
Show reconnecting overlay when socket disconnects. Display actionError/error as dismissible toasts in game pages. Fix silent catch in LobbyPage fetches.

Closes #89