### PR TITLE
Room memory cleanup and stale socket cleanup

### DIFF
--- a/apps/server/src/game/Room.ts
+++ b/apps/server/src/game/Room.ts
@@ -24,10 +24,20 @@ export class Room {
   players: RoomPlayer[] = [];
   state: "waiting" | "playing" | "finished" = "waiting";
   engine: GameEngine | null = null;
+  finishedAt?: number;
+  private cleanupTimer?: ReturnType<typeof setTimeout>;
 
   constructor(ruleSetId: string) {
     this.id = generateRoomId();
     this.ruleSetId = ruleSetId;
+  }
+
+  setFinished(): void {
+    this.state = "finished";
+    this.finishedAt = Date.now();
+    this.cleanupTimer = setTimeout(() => {
+      roomManager.removeRoom(this.id);
+    }, 5 * 60 * 1000);
   }
 
   addPlayer(name: string, socketId?: string, isBot = false): boolean {
@@ -90,8 +100,12 @@ export class Room {
   }
 }
 
+const CLEANUP_INTERVAL_MS = 60 * 1000;
+const FINISHED_ROOM_TTL_MS = 5 * 60 * 1000;
+
 export class RoomManager {
   private rooms = new Map<string, Room>();
+  private cleanupInterval?: ReturnType<typeof setInterval>;
 
   createRoom(ruleSetId: string): Room {
     const room = new Room(ruleSetId);
@@ -110,7 +124,31 @@ export class RoomManager {
   removeRoom(id: string): boolean {
     return this.rooms.delete(id);
   }
+
+  startPeriodicCleanup(): void {
+    if (this.cleanupInterval) return;
+    this.cleanupInterval = setInterval(() => {
+      const now = Date.now();
+      for (const room of this.rooms.values()) {
+        if (
+          room.state === "finished" &&
+          room.finishedAt &&
+          now - room.finishedAt >= FINISHED_ROOM_TTL_MS
+        ) {
+          this.rooms.delete(room.id);
+        }
+      }
+    }, CLEANUP_INTERVAL_MS);
+  }
+
+  stopPeriodicCleanup(): void {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = undefined;
+    }
+  }
 }
 
 // Singleton instance
 export const roomManager = new RoomManager();
+roomManager.startPeriodicCleanup();

--- a/apps/server/src/socketHandlers.ts
+++ b/apps/server/src/socketHandlers.ts
@@ -263,7 +263,7 @@ function buildCallbacks(
       // Only transition to finished after all 16 rounds are complete
       const currentRound = room.engine?.gameState.currentRound ?? 1;
       if (currentRound >= 16) {
-        room.state = "finished";
+        room.setFinished();
       }
     },
   };


### PR DESCRIPTION
Rooms persist in memory forever. Add auto-delete for finished rooms after 5 minutes. Clean up socketToRoom entries on disconnect. Prevent memory leaks on long-running server.

Closes #94