### PR TITLE
Fix round completion off-by-one and startGame race guard

### DIFF
--- a/apps/server/src/socketHandlers.ts
+++ b/apps/server/src/socketHandlers.ts
@@ -95,6 +95,10 @@ export function registerSocketHandlers(
           socket.emit("actionError", { message: "Room not found", code: "ROOM_NOT_FOUND" });
           return;
         }
+        if (room.state !== "waiting") {
+          socket.emit("actionError", { message: "Game already started", code: "ALREADY_STARTED" });
+          return;
+        }
         if (!room.canStart()) {
           socket.emit("actionError", { message: "Cannot start: need exactly 4 players", code: "CANNOT_START" });
           return;
@@ -260,7 +264,10 @@ function buildCallbacks(
     },
     onGameOver: (result) => {
       io.to(room.id).emit("gameOver", result);
-      // Only transition to finished after all 16 rounds are complete
+      // Only transition to finished after all 16 rounds are complete.
+      // currentRound is incremented by resetForNextRound() BEFORE the round
+      // plays, so when round 16's gameOver fires, currentRound is still 16.
+      // The >= 16 check is therefore correct.
       const currentRound = room.engine?.gameState.currentRound ?? 1;
       if (currentRound >= 16) {
         room.setFinished();


### PR DESCRIPTION
1. onGameOver checks currentRound >= 16 but resetForNextRound increments at start of round. Verify counter lifecycle and fix. 2. Add guard in startGame handler: if room.state !== waiting, return early. Prevents double-start race.

Closes #106